### PR TITLE
fix(agentdb): add ESM __dirname polyfill to agentdb-cli.ts

### DIFF
--- a/agentic-flow/src/agentdb/cli/agentdb-cli.ts
+++ b/agentic-flow/src/agentdb/cli/agentdb-cli.ts
@@ -19,6 +19,12 @@ import { SkillLibrary, Skill, SkillQuery } from '../controllers/SkillLibrary.js'
 import { EmbeddingService } from '../controllers/EmbeddingService.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+// ESM __dirname polyfill (required since ES modules don't have __dirname)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Color codes for terminal output
 const colors = {


### PR DESCRIPTION
## Summary

- Fixes the `__dirname is not defined` error in AgentDB CLI when running as an ES module
- Adds standard ESM polyfill using `fileURLToPath` and `dirname` from Node.js built-in modules

## Problem

The `agentic-flow/src/agentdb/cli/agentdb-cli.ts` file uses `__dirname` (line 62) but runs as an ES module where `__dirname` is not available. This causes all MCP tools that rely on the CLI to fail:

```
❌ __dirname is not defined
```

**Affected tools:**
- `agentdb_stats`
- `agentdb_pattern_store`
- `agentdb_pattern_search`
- `agentdb_pattern_stats`

## Solution

Added the standard ESM polyfill:

```typescript
import { fileURLToPath } from 'url';
import { dirname } from 'path';

// ESM __dirname polyfill (required since ES modules don't have __dirname)
const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);
```

## Note

The `packages/agentdb/src/cli/agentdb-cli.ts` already has this polyfill (line 35), but the `agentic-flow/src/agentdb/cli/agentdb-cli.ts` was missing it.

## Test plan

- [x] Verified MCP tools work after applying this fix locally
- [x] `agentdb_stats` returns database statistics
- [x] `agentdb_pattern_store` successfully stores episodes

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)