### PR TITLE
fix: upgrade agentdb dependency from v2 to v3 (broken exports)

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react-swc": "^4.2.0",
     "@xenova/transformers": "^2.17.2",
-    "agentdb": "^2.0.0-alpha.3.6",
+    "agentdb": "^3.0.0-alpha.3",
     "agentic-payments": "^0.1.13",
     "autoprefixer": "^10.4.21",
     "axios": "^1.12.2",


### PR DESCRIPTION
## Summary

- Upgrades `agentdb` from `^2.0.0-alpha.3.6` to `^3.0.0-alpha.3` in root `package.json`
- The v2 line (`2.0.0-alpha.3.7`) has **18 broken exports** in its `package.json` — all `./controllers/*` and `./cli` paths point to `./dist/controllers/` but the TypeScript build outputs to `./dist/src/controllers/`
- The v3 line (`3.0.0-alpha.3+`, already published to npm) has the correct exports map

## Problem

Every consumer of `agentic-flow` that transitively imports `agentdb/controllers` hits:
```
[AgentDB Patch] Controller index not found: node_modules/agentdb/dist/controllers/index.js
```

### Broken paths in agentdb v2 (`2.0.0-alpha.3.7`)
| Export | Points to (wrong) | Actual file (correct) |
|--------|-------------------|----------------------|
| `./controllers` | `./dist/controllers/index.js` | `./dist/src/controllers/index.js` |
| `./controllers/HNSWIndex` | `./dist/controllers/HNSWIndex.js` | `./dist/src/controllers/HNSWIndex.js` |
| ... 16 more | `./dist/controllers/*` | `./dist/src/controllers/*` |
| `./cli` | `./dist/cli/agentdb-cli.js` | `./dist/src/cli/agentdb-cli.js` |

### Already fixed in agentdb v3 (`packages/agentdb/package.json` on main)
All exports correctly use `./dist/src/controllers/` paths.

## Test plan

- [ ] `npm install` resolves `agentdb@^3.0.0-alpha.3` (latest: `3.0.0-alpha.10`)
- [ ] `node -e "import('agentdb/controllers')"` succeeds without errors
- [ ] All 27 exports in agentdb v3 resolve to existing files
- [ ] No runtime regressions in swarm/memory/hooks commands

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)