### PR TITLE
fix: correct AgentDB controller path to dist/src/controllers

### DIFF
--- a/agentic-flow/src/utils/agentdb-runtime-patch.ts
+++ b/agentic-flow/src/utils/agentdb-runtime-patch.ts
@@ -34,7 +34,7 @@ export function applyAgentDBPatch(): boolean {
       return false;
     }
 
-    const controllerIndexPath = join(agentdbPath, 'dist', 'controllers', 'index.js');
+    const controllerIndexPath = join(agentdbPath, 'dist', 'src', 'controllers', 'index.js');
 
     if (!existsSync(controllerIndexPath)) {
       console.warn(`[AgentDB Patch] Controller index not found: ${controllerIndexPath}`);
@@ -159,7 +159,7 @@ export function isAgentDBPatchNeeded(): boolean {
   const agentdbPath = findAgentDBPath();
   if (!agentdbPath) return false;
 
-  const controllerIndexPath = join(agentdbPath, 'dist', 'controllers', 'index.js');
+  const controllerIndexPath = join(agentdbPath, 'dist', 'src', 'controllers', 'index.js');
   if (!existsSync(controllerIndexPath)) return false;
 
   const content = readFileSync(controllerIndexPath, 'utf8');


### PR DESCRIPTION
## Issue
The AgentDB runtime patch was looking for controllers at the wrong path, causing it to fail silently.

**Current (broken):**
`dist/controllers/index.js`

**Correct:**
`dist/src/controllers/index.js`

## Error
```
[AgentDB Patch] Controller index not found: /path/to/agentdb/dist/controllers/index.js
```

## Fix
Updated `agentdb-runtime-patch.ts` to use the correct path structure that matches AgentDB v1.3.9's actual package layout.

## Testing
- Tested with ruflo project
- Daemon now starts without AgentDB patch warnings
- Import resolution works correctly

## Files Changed
- `agentic-flow/src/utils/agentdb-runtime-patch.ts` - Updated 2 path references