### PR TITLE
fix(agentdb): add delete API — closes #150 (ruflo#1784 / RuVector#427 chain)

### DIFF
--- a/packages/agentdb/src/backends/graph/GraphDatabaseAdapter.ts
+++ b/packages/agentdb/src/backends/graph/GraphDatabaseAdapter.ts
@@ -289,6 +289,153 @@ export class GraphDatabaseAdapter {
     await this.db.createEdge(edge);
   }
 
+  // ==========================================================================
+  // Delete API (issue #150 — closes the gap from ruflo#1784 / RuVector#427)
+  //
+  // The native @ruvector/graph-node binding (currently 2.0.4) doesn't expose
+  // direct deleteNode / deleteEdge / deleteHyperedge methods, but `query()`
+  // accepts arbitrary Cypher. We implement deletes by routing through Cypher
+  // so downstream consumers (ruflo's adr-index, agent decommissioning, etc.)
+  // can keep the graph in sync with external sources of truth without
+  // rebuilding the whole database.
+  // ==========================================================================
+
+  /**
+   * Delete a node by id. With `cascade: true` (default) all incident edges
+   * are removed in the same transaction (`DETACH DELETE`); with
+   * `cascade: false` the call refuses when incident edges exist (matching
+   * the spec from RuVector#427).
+   *
+   * @returns `deletedNode`: whether the node existed and was removed.
+   *          `deletedEdges`: count of incident edges removed (only meaningful
+   *          when `cascade: true`).
+   */
+  async deleteNode(
+    id: string,
+    opts: { cascade?: boolean } = {}
+  ): Promise<{ deletedNode: boolean; deletedEdges: number }> {
+    const cascade = opts.cascade !== false;
+    const escaped = this.escapeId(id);
+
+    // Count incident edges before delete so we can return an accurate count
+    // regardless of whether the binding's stats include it.
+    const before = await this.db.query(
+      `MATCH ({id: '${escaped}'})-[r]-() RETURN count(r) AS edgeCount`
+    );
+    const edgeCount = this.firstNumeric(before, 'edgeCount') ?? 0;
+
+    if (!cascade && edgeCount > 0) {
+      throw new Error(
+        `deleteNode('${id}', { cascade: false }): node has ${edgeCount} incident edge(s); ` +
+          `pass cascade: true to remove them in the same transaction.`
+      );
+    }
+
+    const cypher = cascade
+      ? `MATCH (n {id: '${escaped}'}) DETACH DELETE n RETURN count(n) AS deleted`
+      : `MATCH (n {id: '${escaped}'}) DELETE n RETURN count(n) AS deleted`;
+
+    const result = await this.db.query(cypher);
+    const deletedNode = (this.firstNumeric(result, 'deleted') ?? 0) > 0;
+
+    return { deletedNode, deletedEdges: cascade ? edgeCount : 0 };
+  }
+
+  /**
+   * Delete a single edge by id. Endpoints stay intact.
+   */
+  async deleteEdge(id: string): Promise<{ deleted: boolean }> {
+    const escaped = this.escapeId(id);
+    const result = await this.db.query(
+      `MATCH ()-[r {id: '${escaped}'}]-() DELETE r RETURN count(r) AS deleted`
+    );
+    const deleted = (this.firstNumeric(result, 'deleted') ?? 0) > 0;
+    return { deleted };
+  }
+
+  /**
+   * Delete a hyperedge by id. Member nodes stay intact.
+   *
+   * Hyperedges are stored as relationship-like entities in RuVector's graph;
+   * we use the same Cypher pattern as `deleteEdge` but match `:HYPEREDGE`
+   * to disambiguate when the storage represents both as relationships.
+   */
+  async deleteHyperedge(id: string): Promise<{ deleted: boolean }> {
+    const escaped = this.escapeId(id);
+    const result = await this.db.query(
+      `MATCH ()-[r:HYPEREDGE {id: '${escaped}'}]-() DELETE r RETURN count(r) AS deleted`
+    );
+    const deleted = (this.firstNumeric(result, 'deleted') ?? 0) > 0;
+    return { deleted };
+  }
+
+  /**
+   * Delete every edge between two endpoints, optionally filtered by label.
+   * Saves callers the cost of materialising edge ids first when they want to
+   * scrub a `(source, target [, label])` tuple wholesale.
+   */
+  async deleteEdgesByEndpoints(
+    from: string,
+    to: string,
+    label?: string
+  ): Promise<{ deleted: number }> {
+    const f = this.escapeId(from);
+    const t = this.escapeId(to);
+    const labelClause = label ? `:${this.escapeLabel(label)}` : '';
+    const result = await this.db.query(
+      `MATCH ({id: '${f}'})-[r${labelClause}]->({id: '${t}'}) DELETE r RETURN count(r) AS deleted`
+    );
+    const deleted = this.firstNumeric(result, 'deleted') ?? 0;
+    return { deleted };
+  }
+
+  /**
+   * Cypher escaping for ids/strings. We single-quote the value, so any
+   * embedded single quote needs doubling, and backslashes are escaped to
+   * keep the binding's parser happy.
+   */
+  private escapeId(value: string): string {
+    return String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  }
+
+  private escapeLabel(label: string): string {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(label)) {
+      throw new Error(`Invalid graph label: ${label}`);
+    }
+    return label;
+  }
+
+  /**
+   * Pull the first numeric value of column `col` out of a JsQueryResult.
+   * Different binding versions package row data slightly differently
+   * (`rows`, `nodes`, `edges`, `data`); this is the lowest-common-denominator
+   * extractor.
+   */
+  private firstNumeric(result: any, col: string): number | null {
+    if (!result) return null;
+    const candidates: any[] = [];
+    if (Array.isArray(result.rows)) candidates.push(...result.rows);
+    if (Array.isArray(result.data)) candidates.push(...result.data);
+    if (Array.isArray(result.nodes)) candidates.push(...result.nodes);
+    if (Array.isArray(result.edges)) candidates.push(...result.edges);
+    if (Array.isArray(result)) candidates.push(...result);
+
+    for (const row of candidates) {
+      if (row == null) continue;
+      if (typeof row === 'object' && col in row) {
+        const v = row[col];
+        const n = typeof v === 'string' ? Number(v) : v;
+        if (typeof n === 'number' && !Number.isNaN(n)) return n;
+      }
+      if (typeof row === 'object' && row.properties && col in row.properties) {
+        const v = row.properties[col];
+        const n = typeof v === 'string' ? Number(v) : v;
+        if (typeof n === 'number' && !Number.isNaN(n)) return n;
+      }
+    }
+    return null;
+  }
+
   /**
    * Get graph statistics
    */

--- a/packages/agentdb/src/controllers/ReflexionMemory.ts
+++ b/packages/agentdb/src/controllers/ReflexionMemory.ts
@@ -1127,6 +1127,99 @@ export class ReflexionMemory {
   }
 
   /**
+   * Delete an episode by id. Closes the gap from issue #150 (downstream:
+   * ruflo#1784, RuVector#427) — once an episode is written there was no
+   * first-class way to remove it through any backend.
+   *
+   * Strategy mirrors storeEpisode: when a graph backend is present we go
+   * through it (`graphAdapter.deleteNode` / `graphBackend.deleteNode` —
+   * both Cypher-backed under the hood), and we ALWAYS also purge the SQL
+   * `episodes` and `episode_embeddings` rows so durable storage stays in
+   * sync. Vector backend entries are removed too when present.
+   *
+   * @returns True if the episode existed in any backend and was removed.
+   */
+  async deleteEpisode(id: number | string): Promise<boolean> {
+    const numericId = typeof id === 'number' ? id : parseInt(String(id), 10);
+    const stringId = String(id);
+
+    // Invalidate caches up front — failures below shouldn't leave stale reads.
+    this.queryCache.invalidateCategory('episodes');
+    this.queryCache.invalidateCategory('task-stats');
+
+    let removed = false;
+
+    // 1. Graph adapter (AgentDB v2 fast path)
+    if (this.graphBackend && 'storeEpisode' in this.graphBackend) {
+      const adapter = this.graphBackend as any;
+      if (typeof adapter.deleteNode === 'function') {
+        try {
+          // Adapter accepts either the canonical "episode-<id>" key or a raw
+          // id; try the canonical form first since that's what storeEpisode
+          // emits.
+          const r = await adapter.deleteNode(`episode-${numericId}`, { cascade: true });
+          if (r?.deletedNode) removed = true;
+          if (!removed) {
+            const r2 = await adapter.deleteNode(stringId, { cascade: true });
+            if (r2?.deletedNode) removed = true;
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          // eslint-disable-next-line no-console
+          console.warn(`[ReflexionMemory] deleteEpisode: graph adapter delete failed: ${msg}`);
+        }
+      }
+    }
+    // 2. Generic graph backend
+    else if (this.graphBackend && typeof (this.graphBackend as any).deleteNode === 'function') {
+      try {
+        const r = await (this.graphBackend as any).deleteNode(stringId);
+        if (r === true) removed = true;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`[ReflexionMemory] deleteEpisode: graph backend delete failed: ${msg}`);
+      }
+    }
+
+    // 3. Vector backend (HNSW/RuVector); some implementations don't expose
+    //    delete — guard with a feature check.
+    if (this.vectorBackend && typeof (this.vectorBackend as any).delete === 'function') {
+      try {
+        const r = await (this.vectorBackend as any).delete(String(numericId));
+        if (r === true) removed = true;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(`[ReflexionMemory] deleteEpisode: vector backend delete failed: ${msg}`);
+      }
+    }
+
+    // 4. SQL durable storage — always attempt so persistence stays clean
+    //    even when the primary backend was a no-op.
+    if (this.db && typeof this.db.prepare === 'function' && Number.isFinite(numericId)) {
+      try {
+        const embStmt = this.db.prepare(
+          `DELETE FROM episode_embeddings WHERE episode_id = ?`
+        );
+        embStmt.run(numericId);
+        const stmt = this.db.prepare(`DELETE FROM episodes WHERE id = ?`);
+        const r = stmt.run(numericId);
+        const changes = (r as any)?.changes ?? 0;
+        if (changes > 0) removed = true;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!/no such table/i.test(msg)) {
+          // eslint-disable-next-line no-console
+          console.warn(`[ReflexionMemory] deleteEpisode: SQL delete failed: ${msg}`);
+        }
+      }
+    }
+
+    return removed;
+  }
+
+  /**
    * Dual-write helper for issue #128.
    *
    * Inserts the given episode into the SQLite `episodes` and

--- a/packages/agentdb/tests/unit/controllers/ReflexionMemory-delete.test.ts
+++ b/packages/agentdb/tests/unit/controllers/ReflexionMemory-delete.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Verification for issue #150 (agentdb side of ruflo#1784 / RuVector#427).
+ *
+ * Covers:
+ *   - ReflexionMemory.deleteEpisode removes from SQL when no graph/vector
+ *     backend is configured.
+ *   - GraphDatabaseAdapter.deleteNode / deleteEdge / deleteHyperedge /
+ *     deleteEdgesByEndpoints emit the expected Cypher and surface the
+ *     correct boolean / count.
+ *   - cascade: false refuses when incident edges exist.
+ *
+ * The Cypher-emission tests use a fake `db` that records every `query()`
+ * call — so they verify behaviour without standing up the native binding,
+ * which isn't always available in CI.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ReflexionMemory, type Episode } from '../../../src/controllers/ReflexionMemory.js';
+import { GraphDatabaseAdapter } from '../../../src/backends/graph/GraphDatabaseAdapter.js';
+
+// ---------- minimal in-memory SQLite-shaped fake ----------
+type Row = Record<string, any>;
+class InMemoryStmt {
+  constructor(public sql: string, private impl: (params: any[]) => any) {}
+  run(...params: any[]) {
+    return this.impl(params);
+  }
+  all(...params: any[]) {
+    return this.impl(params);
+  }
+  get(...params: any[]) {
+    const all = this.impl(params);
+    return Array.isArray(all) ? all[0] : all;
+  }
+}
+
+class InMemoryDb {
+  private nextEpisodeId = 1;
+  episodes: Row[] = [];
+  embeddings: Row[] = [];
+
+  prepare(sql: string): InMemoryStmt {
+    const norm = sql.replace(/\s+/g, ' ').trim();
+    if (norm.startsWith('INSERT INTO episodes')) {
+      return new InMemoryStmt(sql, (p) => {
+        const id = this.nextEpisodeId++;
+        this.episodes.push({
+          id,
+          ts: Math.floor(Date.now() / 1000),
+          session_id: p[0],
+          task: p[1],
+          input: p[2],
+          output: p[3],
+          critique: p[4],
+          reward: p[5],
+          success: p[6],
+          latency_ms: p[7],
+          tokens_used: p[8],
+          tags: p[9],
+          metadata: p[10],
+        });
+        return { changes: 1, lastInsertRowid: id };
+      });
+    }
+    if (norm.startsWith('INSERT INTO episode_embeddings')) {
+      return new InMemoryStmt(sql, (p) => {
+        this.embeddings.push({ episode_id: p[0], embedding: p[1] });
+        return { changes: 1, lastInsertRowid: p[0] };
+      });
+    }
+    if (norm.startsWith('DELETE FROM episodes')) {
+      return new InMemoryStmt(sql, (p) => {
+        const before = this.episodes.length;
+        this.episodes = this.episodes.filter((e) => e.id !== p[0]);
+        return { changes: before - this.episodes.length, lastInsertRowid: p[0] };
+      });
+    }
+    if (norm.startsWith('DELETE FROM episode_embeddings')) {
+      return new InMemoryStmt(sql, (p) => {
+        const before = this.embeddings.length;
+        this.embeddings = this.embeddings.filter((e) => e.episode_id !== p[0]);
+        return { changes: before - this.embeddings.length, lastInsertRowid: p[0] };
+      });
+    }
+    if (norm.startsWith('SELECT')) {
+      return new InMemoryStmt(sql, () => []);
+    }
+    throw new Error(`InMemoryDb: unsupported SQL: ${norm}`);
+  }
+  exec() {}
+  pragma() {}
+}
+
+class FakeEmbedder {
+  async initialize() {}
+  async embed(_text: string): Promise<Float32Array> {
+    return new Float32Array([1, 0, 0]);
+  }
+}
+
+describe('ReflexionMemory.deleteEpisode (issue #150)', () => {
+  let db: InMemoryDb;
+  let mem: ReflexionMemory;
+
+  beforeEach(() => {
+    db = new InMemoryDb();
+    mem = new ReflexionMemory(db as any, new FakeEmbedder() as any);
+  });
+
+  it('removes the episode and its embedding from SQL', async () => {
+    const epId = await mem.storeEpisode({
+      sessionId: 's1',
+      task: 'demo',
+      reward: 0.9,
+      success: true,
+    } as Episode);
+
+    expect(db.episodes.find((e) => e.id === epId)).toBeDefined();
+    expect(db.embeddings.find((e) => e.episode_id === epId)).toBeDefined();
+
+    const removed = await mem.deleteEpisode(epId);
+    expect(removed).toBe(true);
+    expect(db.episodes.find((e) => e.id === epId)).toBeUndefined();
+    expect(db.embeddings.find((e) => e.episode_id === epId)).toBeUndefined();
+  });
+
+  it('returns false when the episode does not exist', async () => {
+    const removed = await mem.deleteEpisode(99999);
+    expect(removed).toBe(false);
+  });
+
+  it('accepts numeric and string ids interchangeably', async () => {
+    const epId = await mem.storeEpisode({
+      sessionId: 's1',
+      task: 't',
+      reward: 1,
+      success: true,
+    } as Episode);
+    const removed = await mem.deleteEpisode(String(epId));
+    expect(removed).toBe(true);
+  });
+});
+
+// ---------- Cypher-emission tests for GraphDatabaseAdapter ----------
+
+class CypherSpy {
+  calls: string[] = [];
+  rowsToReturn: Record<string, any[]> = {};
+  // Allow tests to set canned return values keyed by RegExp source.
+  pattern(regex: string, rows: any[]) {
+    this.rowsToReturn[regex] = rows;
+  }
+  async query(cypher: string) {
+    this.calls.push(cypher);
+    for (const [src, rows] of Object.entries(this.rowsToReturn)) {
+      if (new RegExp(src).test(cypher)) return { rows };
+    }
+    return { rows: [{ deleted: 0, edgeCount: 0 }] };
+  }
+}
+
+function makeAdapter(db: CypherSpy): GraphDatabaseAdapter {
+  const adapter = new GraphDatabaseAdapter(
+    { storagePath: ':memory:' } as any,
+    {} as any,
+  );
+  // bypass initialize() — inject fake db directly
+  (adapter as any).db = db;
+  return adapter;
+}
+
+describe('GraphDatabaseAdapter delete API (issue #150)', () => {
+  it('deleteNode emits DETACH DELETE and reports edge count', async () => {
+    const db = new CypherSpy();
+    db.pattern('MATCH \\({id:.*}\\)-\\[r\\]-', [{ edgeCount: 3 }]);
+    db.pattern('DETACH DELETE n RETURN', [{ deleted: 1 }]);
+
+    const adapter = makeAdapter(db);
+    const r = await adapter.deleteNode('episode-42');
+
+    expect(r).toEqual({ deletedNode: true, deletedEdges: 3 });
+    expect(db.calls.some((c) => c.includes('DETACH DELETE'))).toBe(true);
+    expect(db.calls.some((c) => c.includes("episode-42"))).toBe(true);
+  });
+
+  it('deleteNode { cascade: false } refuses when incident edges exist', async () => {
+    const db = new CypherSpy();
+    db.pattern('MATCH \\({id:.*}\\)-\\[r\\]-', [{ edgeCount: 2 }]);
+
+    const adapter = makeAdapter(db);
+    await expect(adapter.deleteNode('n1', { cascade: false })).rejects.toThrow(
+      /2 incident edge/,
+    );
+  });
+
+  it('deleteEdge matches by id and returns deleted: true on hit', async () => {
+    const db = new CypherSpy();
+    db.pattern('MATCH \\(\\)-\\[r {id:', [{ deleted: 1 }]);
+    const adapter = makeAdapter(db);
+    const r = await adapter.deleteEdge('edge-7');
+    expect(r).toEqual({ deleted: true });
+    expect(db.calls[0]).toContain("'edge-7'");
+  });
+
+  it('deleteHyperedge scopes the match with :HYPEREDGE label', async () => {
+    const db = new CypherSpy();
+    db.pattern('HYPEREDGE', [{ deleted: 1 }]);
+    const adapter = makeAdapter(db);
+    const r = await adapter.deleteHyperedge('hy-1');
+    expect(r).toEqual({ deleted: true });
+    expect(db.calls[0]).toMatch(/:HYPEREDGE/);
+  });
+
+  it('deleteEdgesByEndpoints returns the count of matched edges', async () => {
+    const db = new CypherSpy();
+    db.pattern('->\\({id:', [{ deleted: 4 }]);
+    const adapter = makeAdapter(db);
+    const r = await adapter.deleteEdgesByEndpoints('a', 'b', 'SUPERSEDES');
+    expect(r).toEqual({ deleted: 4 });
+    expect(db.calls[0]).toContain(":SUPERSEDES");
+  });
+
+  it('deleteEdgesByEndpoints rejects invalid label characters', async () => {
+    const db = new CypherSpy();
+    const adapter = makeAdapter(db);
+    await expect(adapter.deleteEdgesByEndpoints('a', 'b', 'evil; DROP')).rejects.toThrow(
+      /Invalid graph label/,
+    );
+  });
+
+  it('escapes embedded single quotes and backslashes in ids', async () => {
+    const db = new CypherSpy();
+    db.pattern('deleted', [{ deleted: 0 }]);
+    const adapter = makeAdapter(db);
+    await adapter.deleteEdge("ed'ge\\1");
+    // Embedded single quote should appear escaped in the emitted Cypher.
+    expect(db.calls[0]).toContain("ed\\'ge");
+    expect(db.calls[0]).toContain("\\\\1");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the agentdb-side gap from this chain:

- **ruvnet/ruflo#1784** — `agentdb_hierarchical-store` / `agentdb_causal-edge` MCP tools have no delete tools, breaking `/adr-index` re-runs after ADR file deletion.
- **ruvnet/RuVector#427** — closed but the binding-level methods are still pending publish on `@ruvector/graph-node@2.0.4`.
- **ruvnet/agentic-flow#150** — this PR.

The native `@ruvector/graph-node` binding exposes only `createNode` / `createEdge` / `createHyperedge` / `searchHyperedges` as documented methods, but `GraphDatabase.prototype.query(cypher)` is also live. We implement delete by routing through Cypher so consumers get a delete API today without waiting for binding-level methods.

## What ships

### New on `GraphDatabaseAdapter` (`packages/agentdb/src/backends/graph/GraphDatabaseAdapter.ts`)
| Method | Notes |
|---|---|
| `deleteNode(id, { cascade?: boolean }): { deletedNode, deletedEdges }` | Counts incident edges before delete so the count is accurate regardless of binding stats. `cascade: false` refuses with a typed error when edges exist (matches RuVector#427 spec). |
| `deleteEdge(id): { deleted }` | Endpoints stay intact. |
| `deleteHyperedge(id): { deleted }` | Match scoped with `:HYPEREDGE` to disambiguate from regular relationships. |
| `deleteEdgesByEndpoints(from, to, label?): { deleted }` | Saves callers from materialising every edge id when they want to scrub a `(source, target, label)` tuple. |
| `escapeId` / `escapeLabel` | Cypher-injection guards — labels validated against `/^[A-Za-z_][A-Za-z0-9_]*$/` so `'evil; DROP'` throws instead of slipping into the query. |

### New on `ReflexionMemory`
- `deleteEpisode(id: number \| string): boolean` — mirrors the dual-write pattern from #128 in reverse. Routes through graph adapter / generic graph backend / vector backend (when present) AND always purges SQL `episodes` and `episode_embeddings` rows so durable storage stays in sync.

## Tests

**`packages/agentdb/tests/unit/controllers/ReflexionMemory-delete.test.ts`** — 10 tests, all passing:

- 3 `ReflexionMemory.deleteEpisode` tests against an in-memory SQL fake
- 7 `GraphDatabaseAdapter` Cypher-emission tests against a `CypherSpy` that records every `query()` call:
  - `DETACH DELETE` wiring + accurate edge count
  - `cascade: false` refusal with edge count
  - edge-by-id
  - hyperedge `:HYPEREDGE` label scoping
  - endpoint-tuple delete
  - label injection guard
  - id escaping for embedded quotes/backslashes

```
cd packages/agentdb && npx vitest run tests/unit/controllers/ReflexionMemory-delete.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
```

The existing 23-test verification suite for the prior issue fixes (#145, #146, #102, #110, #118/119, #128, #129) is also still passing — no regressions.

## Why Cypher and not bind-level

The native binding doesn't expose `deleteNode` / `deleteEdge` / `deleteHyperedge` even on the latest published `@ruvector/graph-node@2.0.4`. RuVector#427 is closed but those methods aren't on the registry yet. Rather than block on republishing the binding, we route through Cypher (`MATCH (n {id: $id}) DETACH DELETE n RETURN count(n)`) — same end result, no upstream-publish dependency. When the binding ships native methods, this adapter can switch to those without breaking the public API.

## Downstream

Once this is published as `agentdb@3.0.0-alpha.13`, ruvnet/ruflo#1789's stub branches at `bridgeDeleteCausalNode` / `bridgeDeleteCausalEdge` can re-target their primary path at `graphAdapter.deleteNode` / `.deleteEdge`. The SQL fallback then becomes a true fallback — only fires when the graph backend isn't loaded.

Closes #150

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)