### PR TITLE
fix(agentic-jujutsu): add macOS arm64 optional dependency

### DIFF
--- a/packages/agentic-jujutsu/package-lock.json
+++ b/packages/agentic-jujutsu/package-lock.json
@@ -13,7 +13,8 @@
       },
       "bin": {
         "agentic-jujutsu": "bin/cli.js",
-        "jj-agent": "bin/cli.js"
+        "jj-agent": "bin/cli.js",
+        "jj-mcp": "bin/mcp-server.js"
       },
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -24,12 +25,13 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "agentic-jujutsu-darwin-x64": "2.1.1",
-        "agentic-jujutsu-linux-arm-gnueabihf": "2.1.1",
-        "agentic-jujutsu-linux-arm64-musl": "2.1.1",
-        "agentic-jujutsu-linux-x64-gnu": "2.1.1",
-        "agentic-jujutsu-linux-x64-musl": "2.1.1",
-        "agentic-jujutsu-win32-x64-msvc": "2.1.1"
+        "agentic-jujutsu-darwin-arm64": "2.3.6",
+        "agentic-jujutsu-darwin-x64": "2.3.6",
+        "agentic-jujutsu-linux-arm-gnueabihf": "2.3.6",
+        "agentic-jujutsu-linux-arm64-musl": "2.3.6",
+        "agentic-jujutsu-linux-x64-gnu": "2.3.6",
+        "agentic-jujutsu-linux-x64-musl": "2.3.6",
+        "agentic-jujutsu-win32-x64-msvc": "2.3.6"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/packages/agentic-jujutsu/package.json
+++ b/packages/agentic-jujutsu/package.json
@@ -98,11 +98,12 @@
     }
   },
   "optionalDependencies": {
-    "agentic-jujutsu-win32-x64-msvc": "2.3.5",
-    "agentic-jujutsu-darwin-x64": "2.3.5",
-    "agentic-jujutsu-linux-x64-gnu": "2.3.5",
-    "agentic-jujutsu-linux-x64-musl": "2.3.5",
-    "agentic-jujutsu-linux-arm64-musl": "2.3.5",
-    "agentic-jujutsu-linux-arm-gnueabihf": "2.3.5"
+    "agentic-jujutsu-win32-x64-msvc": "2.3.6",
+    "agentic-jujutsu-darwin-x64": "2.3.6",
+    "agentic-jujutsu-darwin-arm64": "2.3.6",
+    "agentic-jujutsu-linux-x64-gnu": "2.3.6",
+    "agentic-jujutsu-linux-x64-musl": "2.3.6",
+    "agentic-jujutsu-linux-arm64-musl": "2.3.6",
+    "agentic-jujutsu-linux-arm-gnueabihf": "2.3.6"
   }
 }


### PR DESCRIPTION
## Summary

Fix `agentic-jujutsu` package metadata so Apple Silicon installs can resolve the generated N-API native package.

## Context

On macOS arm64, `jj-agent` currently fails after a global install because the generated loader attempts to require `agentic-jujutsu-darwin-arm64`, but the main package metadata does not list that platform package as an optional dependency. This was reproduced with `agentic-jujutsu@2.3.6` on Node v24.15.0 / macOS arm64.

Related issue: #159

## Changes

- Add `agentic-jujutsu-darwin-arm64` to `packages/agentic-jujutsu/package.json` optional dependencies.
- Align all platform optional dependency versions with the package version `2.3.6`.
- Update `packages/agentic-jujutsu/package-lock.json` to match package metadata.

## Key Implementation Details

The existing N-API loader already contains the correct macOS arm64 resolution path:

```js
require('agentic-jujutsu-darwin-arm64')
```

This PR makes the package metadata consistent with that loader path so npm can install the platform package once it is published as part of the release process.

## Testing

Verified locally on macOS arm64:

```bash
cd packages/agentic-jujutsu
node -e "const p=require('./package.json'); const lock=require('./package-lock.json'); const deps=p.optionalDependencies; const locked=lock.packages[''].optionalDependencies; for (const name of ['agentic-jujutsu-darwin-arm64','agentic-jujutsu-darwin-x64','agentic-jujutsu-linux-x64-gnu','agentic-jujutsu-linux-x64-musl','agentic-jujutsu-linux-arm64-musl','agentic-jujutsu-linux-arm-gnueabihf','agentic-jujutsu-win32-x64-msvc']) { if (deps[name] !== '2.3.6') throw new Error('package.json mismatch '+name); if (locked[name] !== '2.3.6') throw new Error('lock mismatch '+name); } console.log('optionalDependencies metadata ok');"
npm pack --dry-run
npm run build
node -e "const m=require('./'); console.log(Object.keys(m).includes('JjWrapper') ? 'native load ok' : 'missing JjWrapper')"
node bin/cli.js version
```

Also passed repository pre-push checks when pushing the branch:

```bash
npm test
tsc --noEmit --project ./agentic-flow/config/tsconfig.json
```

## Notes

The npm registry still needs a published `agentic-jujutsu-darwin-arm64@2.3.6` artifact for the existing released version to install cleanly on Apple Silicon.