### PR TITLE
feat: add governed MetaHarness promotion and MCP profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,9 @@ jobs:
     if: always()
     needs: [governance, compatibility, package]
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
     steps:
       - name: Require all release checks
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,283 +1,87 @@
-name: Test Suite - London School TDD
+name: Agentic Flow Quality Gate
 
 on:
   push:
-    branches: [ main, develop, feature/** ]
+    branches: [main, develop, feature/**]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
   schedule:
-    # Run nightly at 2 AM UTC
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
-env:
-  NODE_VERSION: '18.x'
-  COVERAGE_THRESHOLD: 95
+permissions:
+  contents: read
+
+concurrency:
+  group: agentic-flow-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: agentic-flow
 
 jobs:
-  unit-tests:
-    name: Unit Tests (London School)
+  governance:
+    name: Governance and Type Safety
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
+          node-version: "20.x"
+          cache: npm
+          cache-dependency-path: agentic-flow/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npx tsc -p config/tsconfig.json --skipLibCheck --noEmit
+      - run: npm run test:governance
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run unit tests
-        run: npm test -- --testPathPattern=unit --coverage --maxWorkers=2
-        env:
-          NODE_ENV: test
-
-      - name: Verify unit test coverage
-        run: |
-          COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.lines.pct')
-          echo "Unit test coverage: ${COVERAGE}%"
-          if (( $(echo "$COVERAGE < $COVERAGE_THRESHOLD" | bc -l) )); then
-            echo "Coverage ${COVERAGE}% is below threshold ${COVERAGE_THRESHOLD}%"
-            exit 1
-          fi
-
-      - name: Upload unit coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/lcov.info
-          flags: unit
-          name: unit-coverage
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run integration tests
-        run: npm test -- --testPathPattern=integration --coverage --maxWorkers=2
-        env:
-          NODE_ENV: test
-          DATABASE_PATH: ':memory:'
-
-      - name: Upload integration coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/lcov.info
-          flags: integration
-          name: integration-coverage
-
-  e2e-tests:
-    name: End-to-End Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run E2E tests
-        run: npm test -- --testPathPattern=e2e --coverage --maxWorkers=1
-        env:
-          NODE_ENV: test
-          DATABASE_PATH: ':memory:'
-
-      - name: Upload E2E coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/lcov.info
-          flags: e2e
-          name: e2e-coverage
-
-  performance-tests:
-    name: Performance Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run performance tests
-        run: npm test -- --testPathPattern=performance --maxWorkers=2
-        env:
-          NODE_ENV: test
-          BENCHMARK_MODE: true
-
-      - name: Upload performance results
-        uses: actions/upload-artifact@v4
-        with:
-          name: performance-results
-          path: coverage/performance-*.json
-
-  backwards-compatibility:
-    name: Backwards Compatibility Tests
+  compatibility:
+    name: Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run backwards compatibility tests
-        run: npm test -- --testPathPattern=backwards --maxWorkers=2
-        env:
-          NODE_ENV: test
-
-  coverage-report:
-    name: Generate Coverage Report
-    needs: [unit-tests, integration-tests, e2e-tests]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run all tests with coverage
-        run: npm test -- --coverage --maxWorkers=2
-        env:
-          NODE_ENV: test
-
-      - name: Generate coverage badge
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/lcov.info
-          flags: all
-          name: full-coverage
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/
-
-      - name: Comment coverage on PR
-        if: github.event_name == 'pull_request'
-        uses: romeovs/lcov-reporter-action@v0.3.1
-        with:
-          lcov-file: ./coverage/lcov.info
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify global coverage threshold
-        run: |
-          COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.lines.pct')
-          echo "Global coverage: ${COVERAGE}%"
-          if (( $(echo "$COVERAGE < $COVERAGE_THRESHOLD" | bc -l) )); then
-            echo "❌ Coverage ${COVERAGE}% is below threshold ${COVERAGE_THRESHOLD}%"
-            exit 1
-          fi
-          echo "✅ Coverage ${COVERAGE}% meets threshold ${COVERAGE_THRESHOLD}%"
-
-  test-matrix:
-    name: Test on Node ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: ['18.x', '20.x', '22.x']
-
+        node-version: ["20.x", "22.x"]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: agentic-flow/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npm test
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npm test -- --maxWorkers=2
-        env:
-          NODE_ENV: test
+  package:
+    name: Build and Package
+    needs: governance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: npm
+          cache-dependency-path: agentic-flow/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npm pack --dry-run
 
   quality-gate:
     name: Quality Gate
-    needs: [unit-tests, integration-tests, e2e-tests, coverage-report]
-    runs-on: ubuntu-latest
     if: always()
-
-    steps:
-      - name: Check test results
-        run: |
-          if [ "${{ needs.unit-tests.result }}" != "success" ] || \
-             [ "${{ needs.integration-tests.result }}" != "success" ] || \
-             [ "${{ needs.e2e-tests.result }}" != "success" ] || \
-             [ "${{ needs.coverage-report.result }}" != "success" ]; then
-            echo "❌ Quality gate failed - tests or coverage below threshold"
-            exit 1
-          fi
-          echo "✅ Quality gate passed - all tests successful and coverage meets threshold"
-
-  notify:
-    name: Notify Results
-    needs: [quality-gate]
+    needs: [governance, compatibility, package]
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'push'
-
     steps:
-      - name: Send notification
+      - name: Require all release checks
+        env:
+          GOVERNANCE: ${{ needs.governance.result }}
+          COMPATIBILITY: ${{ needs.compatibility.result }}
+          PACKAGE: ${{ needs.package.result }}
         run: |
-          if [ "${{ needs.quality-gate.result }}" == "success" ]; then
-            echo "✅ All tests passed with coverage >= ${COVERAGE_THRESHOLD}%"
-          else
-            echo "❌ Tests failed or coverage below ${COVERAGE_THRESHOLD}%"
-          fi
+          test "$GOVERNANCE" = success
+          test "$COMPATIBILITY" = success
+          test "$PACKAGE" = success

--- a/agentic-flow/package-lock.json
+++ b/agentic-flow/package-lock.json
@@ -13,15 +13,14 @@
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.65.0",
         "@google/genai": "^1.22.0",
-        "@metaharness/darwin": "^0.7.0",
+        "@huggingface/transformers": "^3.8.1",
         "@metaharness/router": "^0.3.2",
         "@ruvector/core": "^0.1.29",
         "@ruvector/edge-full": "^0.1.0",
-        "@ruvector/router": "^0.1.25",
-        "@ruvector/ruvllm": "^0.2.3",
+        "@ruvector/router": "^0.1.30",
+        "@ruvector/ruvllm": "^2.5.5",
         "@ruvector/tiny-dancer": "^0.1.17",
         "@supabase/supabase-js": "^2.78.0",
-        "@xenova/transformers": "^2.17.2",
         "axios": "^1.12.2",
         "dotenv": "^16.4.5",
         "express": "^5.1.0",
@@ -29,7 +28,7 @@
         "glob": "^13.0.0",
         "gun": "^0.2020.1241",
         "http-proxy-middleware": "^3.0.5",
-        "ruvector": "^0.1.85",
+        "ruvector": "0.2.40",
         "ruvector-onnx-embeddings-wasm": "^0.1.2",
         "tiktoken": "^1.0.22",
         "ulid": "^3.0.1",
@@ -55,7 +54,7 @@
         "vitest": "^4.0.14"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-darwin-arm64": "^4.59.0",
@@ -64,7 +63,7 @@
         "agentdb": "^3.0.0-alpha.14",
         "better-sqlite3": "^11.10.0",
         "onnxruntime-node": "^1.23.2",
-        "sharp": "^0.32.6",
+        "sharp": "^0.34.3",
         "sql.js": "^1.11.0"
       }
     },
@@ -169,10 +168,292 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
+      "integrity": "sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.11.tgz",
+      "integrity": "sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.11.tgz",
+      "integrity": "sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.11.tgz",
+      "integrity": "sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.11.tgz",
+      "integrity": "sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.11.tgz",
+      "integrity": "sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.11.tgz",
+      "integrity": "sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.11.tgz",
+      "integrity": "sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.11.tgz",
+      "integrity": "sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.11.tgz",
+      "integrity": "sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.11.tgz",
+      "integrity": "sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.11.tgz",
+      "integrity": "sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.11.tgz",
+      "integrity": "sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.11.tgz",
+      "integrity": "sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.11",
@@ -184,6 +465,159 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.11.tgz",
+      "integrity": "sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.11.tgz",
+      "integrity": "sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.11.tgz",
+      "integrity": "sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.11.tgz",
+      "integrity": "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.11.tgz",
+      "integrity": "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -323,8 +757,265 @@
     "node_modules/@huggingface/jinja": {
       "version": "0.2.2",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
@@ -339,6 +1030,169 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
@@ -359,6 +1213,132 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/external-editor": {
@@ -421,6 +1401,18 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "dev": true,
@@ -455,12 +1447,40 @@
       }
     },
     "node_modules/@metaharness/darwin": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.7.0.tgz",
-      "integrity": "sha512-ApndPhj982QXPN2ARedxki+iA1xiyk9hbLXu8tJo9kEcjw37T+/2wrZLgvaTfLSHfGmg87qbtrV8dCZT/20/oQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.8.0.tgz",
+      "integrity": "sha512-Pgefr/es0Btofh7GxQrOAg/i43ZKcLUfeD9rndOAkpA8s3ZYohSmfLerJLNsGOOKc2eTvmmauljl8QEVmKC2dw==",
       "license": "MIT",
       "bin": {
         "metaharness-darwin": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@metaharness/flywheel": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@metaharness/flywheel/-/flywheel-0.1.7.tgz",
+      "integrity": "sha512-am7dROkjyS1Zkms3TOcn2LVHjwMLQXPJ6Pu1aP55q40vWJLRONGdGvnrcBL/VhMFqjQrVB57lmSn2E+s5CSZwA==",
+      "license": "MIT"
+    },
+    "node_modules/@metaharness/harness": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/harness/-/harness-0.1.0.tgz",
+      "integrity": "sha512-KegYx/q8qXlnaSYP0l5hgNPn8iNMl6a2eONqPi68FXd1w1jt7NswJJlt2/Ftl3Sum8qAEchxH1ZJOYFWTvJxTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@metaharness/redblue": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@metaharness/redblue/-/redblue-0.1.4.tgz",
+      "integrity": "sha512-JaAk6bs3xA7Ks5RnAcZoxI3WfzpYL+Bk262SCI07w82BDOA7C6VxwGM63F7b86lRTKUVjTEnSqf7QZ3uyElT/g==",
+      "license": "MIT",
+      "bin": {
+        "metaharness-redblue": "dist/cli/index.js",
+        "redblue": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -483,11 +1503,43 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
+    "node_modules/@metaharness/weight-eft": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@metaharness/weight-eft/-/weight-eft-0.1.1.tgz",
+      "integrity": "sha512-GSg0APPAbRK93OzrzlE+R8hfEK+I5+Zhmh0Z28RC9Mk5/MjhPo3shqINO7ye8VPGYHIO4rars9FwCWbe/V4cEQ==",
+      "license": "MIT",
+      "bin": {
+        "weight-eft": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@metaharness/workspace-lens": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@metaharness/workspace-lens/-/workspace-lens-0.1.1.tgz",
+      "integrity": "sha512-BkEdTvjD2PEhkGTCmtTIPnoeaOsxvzFtsFEAurwVKlVOu4hQetHeXDfiyAYheWg8Cp4fcGcr7E5MO1ptQveQ2g==",
+      "license": "MIT"
+    },
+    "node_modules/@metaharness/workspace-probe": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@metaharness/workspace-probe/-/workspace-probe-0.1.1.tgz",
+      "integrity": "sha512-kHL7T16476a5obVunbZ2NYqK7YY/1qtZTaQC1KyXmFh/7dRNselqGAilawspuD86F9U1H/LMCDvchDj3Vh5duw==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@metaharness/workspace-lens": "^0.1.0"
+      },
+      "bin": {
+        "workspace-probe": "bin/workspace-probe.mjs"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1788,6 +2840,19 @@
         "@ruvector/attention-win32-x64-msvc": "0.1.4"
       }
     },
+    "node_modules/@ruvector/attention-darwin-x64": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/attention-darwin-x64/-/attention-darwin-x64-0.1.4.tgz",
+      "integrity": "sha512-JKpYFtHPlXrxNtOWfQiMLGJzOzBxZS7fmLzcesOl9/VNQKlCLkC8JB0SCsA0ZlION2CFBJhburYg9j0knWgWqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@ruvector/attention-linux-x64-gnu": {
       "version": "0.1.4",
       "cpu": [
@@ -1797,6 +2862,19 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@ruvector/attention-win32-x64-msvc": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/attention-win32-x64-msvc/-/attention-win32-x64-msvc-0.1.4.tgz",
+      "integrity": "sha512-DZOrU2J1dKphv1vJyce3pvx0RY6asEGU2Er7xkxQIBpckyEhBGKV5P2tuFbv0M1IzQ1FNQxRX8uv1bpgmJIA+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@ruvector/core": {
@@ -2176,23 +3254,62 @@
       }
     },
     "node_modules/@ruvector/router": {
-      "version": "0.1.25",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@ruvector/router/-/router-0.1.30.tgz",
+      "integrity": "sha512-gtZAdxp0UYrOJd3Kz+kNtFNfG53aW2xkZ7u3XNT+JdViTEVnpYMEdDfpc2ByQBy+kf600Cp5xVMQR3qVXajWtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@ruvector/router-darwin-arm64": "0.1.25",
-        "@ruvector/router-darwin-x64": "0.1.15",
-        "@ruvector/router-linux-arm64-gnu": "0.1.25",
-        "@ruvector/router-linux-x64-gnu": "0.1.25",
-        "@ruvector/router-win32-x64-msvc": "0.1.25"
+        "@ruvector/router-darwin-arm64": "0.1.30",
+        "@ruvector/router-darwin-x64": "0.1.30",
+        "@ruvector/router-linux-arm64-gnu": "0.1.30",
+        "@ruvector/router-linux-x64-gnu": "0.1.30",
+        "@ruvector/router-win32-x64-msvc": "0.1.30"
       }
     },
-    "node_modules/@ruvector/router-linux-x64-gnu": {
-      "version": "0.1.25",
+    "node_modules/@ruvector/router-darwin-arm64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@ruvector/router-darwin-arm64/-/router-darwin-arm64-0.1.30.tgz",
+      "integrity": "sha512-TWC8ei18jlODekVwSyzEC55XUnmgU+br1cD/w7I3iEW6FL6Vbl3neZU8b03cHtgEN9xxnrKDRr7jq3T41UY40A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@ruvector/router-darwin-x64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@ruvector/router-darwin-x64/-/router-darwin-x64-0.1.30.tgz",
+      "integrity": "sha512-nxnPGUx2BYAgSzJ3bC/hiCOVAPnAORvJToKnwRV3V+b/KhuUd09qSEP1ykUjbT4Y8oxnA4DklTvVTMwKRFFE1w==",
       "cpu": [
         "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ruvector/router-linux-arm64-gnu": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@ruvector/router-linux-arm64-gnu/-/router-linux-arm64-gnu-0.1.30.tgz",
+      "integrity": "sha512-7FD16wlCVgQ+4Zvd3d5noTRrCpbT2SvEzmhVj+L9HVV3u8NHCfHVLSb8gObf9RS9PW1X4pm60b5X39SgxKbDTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2200,11 +3317,48 @@
         "linux"
       ],
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ruvector/router-linux-x64-gnu": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@ruvector/router-linux-x64-gnu/-/router-linux-x64-gnu-0.1.30.tgz",
+      "integrity": "sha512-NHognWMJBEfoRt5+22TvYAoA+XPzZpd1DHP3z4fLAoKI85SZOqYy9sxyZo/oyYVsMDPrrBJKi3wdufPzgLFeOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ruvector/router-win32-x64-msvc": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@ruvector/router-win32-x64-msvc/-/router-win32-x64-msvc-0.1.30.tgz",
+      "integrity": "sha512-E9j57ZMVS9CvHYwlPyBEZfmbMoMySWePUcqlhktglZbA22BD1soYUgIKPf2jUkEJTLfxvwLDqBjtyNThXAojiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@ruvector/ruvllm": {
-      "version": "0.2.4",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm/-/ruvllm-2.6.0.tgz",
+      "integrity": "sha512-aXAIYTtjtsxINagNY9451/9+lbLO24yAKqLqRxad/FlkgJcR3uicMQCwayH/pFP0PbgGI5bQAL0PvkDC4Zz0lA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -2218,11 +3372,11 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@ruvector/ruvllm-darwin-arm64": "0.2.0",
-        "@ruvector/ruvllm-darwin-x64": "0.2.0",
-        "@ruvector/ruvllm-linux-arm64-gnu": "0.2.0",
-        "@ruvector/ruvllm-linux-x64-gnu": "0.2.0",
-        "@ruvector/ruvllm-win32-x64-msvc": "0.2.0"
+        "@ruvector/ruvllm-darwin-arm64": "2.0.1",
+        "@ruvector/ruvllm-darwin-x64": "2.0.1",
+        "@ruvector/ruvllm-linux-arm64-gnu": "2.0.1",
+        "@ruvector/ruvllm-linux-x64-gnu": "2.0.1",
+        "@ruvector/ruvllm-win32-x64-msvc": "2.0.1"
       }
     },
     "node_modules/@ruvector/ruvllm-darwin-arm64": {
@@ -2274,9 +3428,14 @@
       }
     },
     "node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "version": "0.2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-linux-x64-gnu/-/ruvllm-linux-x64-gnu-2.0.1.tgz",
+      "integrity": "sha512-GH9u/SPUZm9KXjSoQZx5PRtJui0hO/OK+OmRHLZc8+IYrlgona6UQAw6uKHJ3cSEZp9f+XBRYgIrLmsEJW3HXA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -2291,70 +3450,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-win32-x64-msvc/-/ruvllm-win32-x64-msvc-2.0.1.tgz",
       "integrity": "sha512-sRGNOMAcyC5p/nITnR0HLFUEObZ9Mh/T1erNiqhKrNUqIPZM1qAYBgN3xmZp02isdiTilRpxQihz3j4EzGPXIw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-darwin-arm64/-/ruvllm-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-3oEMNEoGJqfTJXf1Th49HPTlETMxLzlBc1yBY1RqCMoqSrNKsM66+3Npx0O/GdYfFnKRU2wa/mlLPuBY2lUqYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-darwin-x64/-/ruvllm-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-Niu9oG9hkbDJ1IpfXluRRfO4vwPwCdISW+ff1H+NjmIk8028CIg2w5iq3qbIaj6WzTQ9YqA68V5aMD9t0w8A6g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-linux-arm64-gnu/-/ruvllm-linux-arm64-gnu-0.2.0.tgz",
-      "integrity": "sha512-ykOqwiqRbf29idXYMmuDdZqOsRMbYgzpWhmk/BcSRVBMUsO4W2Q0UkgLZgt6PIKxSf1k2qt8x8uSmO5tYTD8Iw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-win32-x64-msvc/-/ruvllm-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-ksm+AZVqkkYLVq2Rbc7Rx+gSH7egFWlcH3E5dQpro98Oslc7jUH+uNDRjDVUS3lZXchV+Ot5WPLM4pClRxFm9w==",
       "cpu": [
         "x64"
       ],
@@ -2507,6 +3602,45 @@
         "@ruvector/sona-win32-x64-msvc": "0.1.4"
       }
     },
+    "node_modules/@ruvector/sona-darwin-arm64": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/sona-darwin-arm64/-/sona-darwin-arm64-0.1.4.tgz",
+      "integrity": "sha512-XLXGnlcrrVM00cTsq7VyGhWu2Fvr4zJQD1bktthR3j0r4Y1PXwnw1QPHVtdcKzKmZ5WKPDGxsgRNPUKAIT/PRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ruvector/sona-darwin-x64": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/sona-darwin-x64/-/sona-darwin-x64-0.1.4.tgz",
+      "integrity": "sha512-8bUvmQHn/N7zcD5Zf/u+lsggl6ql0NiuwPPYxitimJKAV+8oT7Zt4zE7kgnx8wqO2YCD4GPxw5laqhRz6IWwQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ruvector/sona-linux-arm64-gnu": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/sona-linux-arm64-gnu/-/sona-linux-arm64-gnu-0.1.4.tgz",
+      "integrity": "sha512-QyGIK++wbdRDTF2oio1Ikq1QjS5KKUKJx4Z/rRjxJu29TGXigEdJmwTnPDtsKKzVwXahrEi1mI4Ri/ALMJID9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@ruvector/sona-linux-x64-gnu": {
       "version": "0.1.4",
       "cpu": [
@@ -2527,6 +3661,32 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@ruvector/sona-win32-arm64-msvc": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/sona-win32-arm64-msvc/-/sona-win32-arm64-msvc-0.1.4.tgz",
+      "integrity": "sha512-xQkFe5x8SBcg+IM/I5EtDz7gQYdznG1GZnAqt9zKbY/xEOqPmJFlk9A8ab3w9QMBgXTCmlZKkWKDGQgqg3RQ5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ruvector/sona-win32-x64-msvc": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ruvector/sona-win32-x64-msvc/-/sona-win32-x64-msvc-0.1.4.tgz",
+      "integrity": "sha512-kox5tXvKiTtZaSw0fyo7fvAIp/VK5XAtnoN8C8BuERcqOgrcwY6CS8z5M1hEH1XUR9CHBNpiL6+wURsLXwq4/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@ruvector/tiny-dancer": {
@@ -3064,6 +4224,7 @@
     "node_modules/@xenova/transformers": {
       "version": "2.17.2",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@huggingface/jinja": "^0.2.2",
         "onnxruntime-web": "1.14.0",
@@ -3084,6 +4245,58 @@
       ],
       "dependencies": {
         "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/@xenova/transformers/node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@xenova/transformers/node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/@xenova/transformers/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -3187,48 +4400,33 @@
         "ruvector-graph-transformer-wasm": "^2.0.4"
       }
     },
-    "node_modules/agentdb/node_modules/@ruvector/ruvllm": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm/-/ruvllm-2.5.5.tgz",
-      "integrity": "sha512-3WDQkN1EiRlmln6Y3qHIOwIRaRUWwagT1OG+AxohyFgr2UuvWCD5tsiPFtlgwUze4X01lgvBCiHdOsV3u81UWA==",
-      "license": "MIT OR Apache-2.0",
+    "node_modules/agentdb/node_modules/ruvector": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/ruvector/-/ruvector-0.1.100.tgz",
+      "integrity": "sha512-goVV/mB28sQmai+eU1DMAtZEg2qQSKes3NtIHjyjN53hHWqwCdIyjZwBEd1WKDysL9mJ4CnSCVC9uaJyStzBIA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@ruvector/attention": "^0.1.3",
+        "@ruvector/core": "^0.1.25",
+        "@ruvector/gnn": "^0.1.22",
+        "@ruvector/sona": "^0.1.4",
         "chalk": "^4.1.2",
-        "commander": "^12.0.0",
+        "commander": "^11.1.0",
         "ora": "^5.4.1"
       },
       "bin": {
-        "ruvllm": "bin/cli.js"
+        "ruvector": "bin/cli.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "@ruvector/ruvllm-darwin-arm64": "2.0.1",
-        "@ruvector/ruvllm-darwin-x64": "2.0.1",
-        "@ruvector/ruvllm-linux-arm64-gnu": "2.0.1",
-        "@ruvector/ruvllm-linux-x64-gnu": "2.0.1",
-        "@ruvector/ruvllm-win32-x64-msvc": "2.0.1"
+        "@ruvector/rvf": "^0.1.0"
       }
     },
-    "node_modules/agentdb/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-linux-x64-gnu/-/ruvllm-linux-x64-gnu-2.0.1.tgz",
-      "integrity": "sha512-GH9u/SPUZm9KXjSoQZx5PRtJui0hO/OK+OmRHLZc8+IYrlgona6UQAw6uKHJ3cSEZp9f+XBRYgIrLmsEJW3HXA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/agentdb/node_modules/@ruvector/ruvllm/node_modules/chalk": {
+    "node_modules/agentdb/node_modules/ruvector/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -3243,6 +4441,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/agentdb/node_modules/ruvector/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ajv": {
@@ -3378,8 +4586,11 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.7.3",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
+      "optional": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -3390,8 +4601,11 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.1",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
+      "optional": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3402,7 +4616,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.0",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3424,34 +4640,33 @@
         }
       }
     },
-    "node_modules/bare-os": {
-      "version": "3.6.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
     "node_modules/bare-path": {
-      "version": "3.0.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
       "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "optional": true
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "streamx": "^2.21.0"
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
@@ -3461,7 +4676,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.1",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3558,8 +4775,7 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -3674,7 +4890,8 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -3815,7 +5032,10 @@
     },
     "node_modules/color": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -3840,7 +5060,10 @@
     },
     "node_modules/color-string": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -3958,6 +5181,7 @@
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -3971,6 +5195,7 @@
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3987,7 +5212,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -4004,7 +5228,6 @@
     "node_modules/define-properties": {
       "version": "1.2.1",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -4040,8 +5263,7 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4091,6 +5313,7 @@
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4139,8 +5362,7 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.11",
@@ -4196,7 +5418,6 @@
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -4225,7 +5446,10 @@
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -4274,6 +5498,7 @@
     "node_modules/expand-template": {
       "version": "2.0.3",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -4353,7 +5578,10 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -4485,7 +5713,8 @@
     },
     "node_modules/flatbuffers": {
       "version": "1.12.0",
-      "license": "SEE LICENSE IN LICENSE.txt"
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -4562,7 +5791,8 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -4707,7 +5937,8 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob": {
       "version": "13.0.0",
@@ -4724,17 +5955,9 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob/node_modules/minipass": {
-      "version": "7.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/global-agent": {
       "version": "3.0.0",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "es6-error": "^4.1.1",
@@ -4750,7 +5973,6 @@
     "node_modules/globalthis": {
       "version": "1.0.4",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -4856,7 +6078,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -5033,7 +6254,8 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/inquirer": {
       "version": "9.3.8",
@@ -5073,7 +6295,10 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -5311,8 +6536,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -5397,6 +6621,21 @@
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -5493,7 +6732,8 @@
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5530,7 +6770,6 @@
     "node_modules/matcher": {
       "version": "3.0.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -5567,6 +6806,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/metaharness": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/metaharness/-/metaharness-0.4.2.tgz",
+      "integrity": "sha512-h94B47zBEuNEfKLFMZMV/fRnXBrkwV6L8kMukgioB/9621k6Lm6s2lR2gBKl3BAT1sfN/DYqhsqAJc+6H5PTGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/darwin": "^0.2.2",
+        "@metaharness/flywheel": "^0.1.1",
+        "@metaharness/redblue": "^0.1.1",
+        "@metaharness/weight-eft": "^0.1.0",
+        "kolorist": "^1.8.0",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "harness": "dist/harness-bin.js",
+        "metaharness": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@ruvector/ruvllm": "^2.5.6"
+      },
+      "peerDependencies": {
+        "@metaharness/kernel": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@metaharness/kernel": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/metaharness/node_modules/@metaharness/darwin": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.2.8.tgz",
+      "integrity": "sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==",
+      "license": "MIT",
+      "bin": {
+        "metaharness-darwin": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/micromatch": {
@@ -5609,6 +6892,7 @@
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -5631,14 +6915,37 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -5678,7 +6985,8 @@
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -5690,6 +6998,7 @@
     "node_modules/node-abi": {
       "version": "3.78.0",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -5699,7 +7008,10 @@
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -5787,7 +7099,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5837,13 +7148,15 @@
     "node_modules/onnx-proto": {
       "version": "4.0.4",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "protobufjs": "^6.8.8"
       }
     },
     "node_modules/onnxruntime-common": {
       "version": "1.14.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/onnxruntime-node": {
       "version": "1.23.2",
@@ -5869,6 +7182,7 @@
     "node_modules/onnxruntime-web": {
       "version": "1.14.0",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "flatbuffers": "^1.12.0",
         "guid-typescript": "^1.0.9",
@@ -6039,13 +7353,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
       "license": "MIT",
@@ -6115,6 +7422,7 @@
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -6147,6 +7455,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/protobufjs": {
@@ -6187,6 +7508,7 @@
     "node_modules/pump": {
       "version": "3.0.3",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6258,6 +7580,7 @@
     "node_modules/rc": {
       "version": "1.2.8",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6368,7 +7691,6 @@
     "node_modules/roarr": {
       "version": "2.15.4",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
@@ -6458,24 +7780,58 @@
       }
     },
     "node_modules/ruvector": {
-      "version": "0.1.95",
+      "version": "0.2.40",
+      "resolved": "https://registry.npmjs.org/ruvector/-/ruvector-0.2.40.tgz",
+      "integrity": "sha512-PHvu4sP1Qqm12IXlzpuy3Fy8R8tt6jpetklTC2jSN0kZWwHdsaw7YvOnE8FcYFOJDbd+OvzFQvSlGiwoQq6+UQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@metaharness/darwin": "0.8.0",
+        "@metaharness/flywheel": "0.1.7",
+        "@metaharness/harness": "0.1.0",
+        "@metaharness/redblue": "0.1.4",
+        "@metaharness/router": "0.3.2",
+        "@metaharness/weight-eft": "0.1.1",
+        "@metaharness/workspace-lens": "0.1.1",
+        "@metaharness/workspace-probe": "0.1.1",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@ruvector/attention": "^0.1.3",
         "@ruvector/core": "^0.1.25",
         "@ruvector/gnn": "^0.1.22",
         "@ruvector/sona": "^0.1.4",
-        "@xenova/transformers": "^2.17.2",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
+        "metaharness": "0.4.2",
         "ora": "^5.4.1"
       },
       "bin": {
         "ruvector": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@ruvector/rvf": "^0.1.0",
+        "@ruvector/tiny-dancer": "^0.1.22"
+      },
+      "peerDependencies": {
+        "@ruvector/diskann": ">=0.1.0",
+        "@ruvector/pi-brain": ">=0.1.0",
+        "@ruvector/router": ">=0.1.0",
+        "@ruvector/ruvllm": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ruvector/diskann": {
+          "optional": true
+        },
+        "@ruvector/pi-brain": {
+          "optional": true
+        },
+        "@ruvector/router": {
+          "optional": true
+        },
+        "@ruvector/ruvllm": {
+          "optional": true
+        }
       }
     },
     "node_modules/ruvector-attention-wasm": {
@@ -6488,6 +7844,45 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/ruvector-core-darwin-arm64": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/ruvector-core-darwin-arm64/-/ruvector-core-darwin-arm64-0.1.29.tgz",
+      "integrity": "sha512-gjZ1/J/0Nh9Mn74VdifIIkPLP/M4FqD/g+QVxWcfWcNFWhHVz+zHyxGjc6gJgrfYBquiMyP5jLfvyR3TffLanQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/ruvector-core-darwin-x64": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/ruvector-core-darwin-x64/-/ruvector-core-darwin-x64-0.1.29.tgz",
+      "integrity": "sha512-SNq2DrIBWM53qG3YSYcNV/BnBbAoJouafAADOjG3PkM8+RPrIucTeUDBavf148DNo5ZI337IS8TK1/0HpJEwFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/ruvector-core-linux-arm64-gnu": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/ruvector-core-linux-arm64-gnu/-/ruvector-core-linux-arm64-gnu-0.1.29.tgz",
+      "integrity": "sha512-gcA2qSQD9nEeHR8pIXr5SKpQAiHMxu4EyBUwUSG4UnWOxVQnnU0l2kA/Z2NZ6B+JWLrb5+nhkkv7AaSmb8YAsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/ruvector-core-linux-x64-gnu": {
       "version": "0.1.29",
       "cpu": [
@@ -6497,6 +7892,19 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/ruvector-core-win32-x64-msvc": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/ruvector-core-win32-x64-msvc/-/ruvector-core-win32-x64-msvc-0.1.29.tgz",
+      "integrity": "sha512-nqHrlUAKpTreGO87jQLtFVrQUBT/7J/dBsPD5/mV9Fet/shncN0QMij7YqBTrlhR9qtQ2gAUGrG0zw69T60AiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/ruvector-graph-transformer-wasm": {
@@ -6576,8 +7984,7 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -6602,7 +8009,6 @@
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
       },
@@ -6616,7 +8022,6 @@
     "node_modules/serialize-error/node_modules/type-fest": {
       "version": "0.13.1",
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -6658,45 +8063,274 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.32.6",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/sharp/node_modules/tar-fs": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
+    "node_modules/sharp/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/sharp/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
+    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/sharp/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/shebang-command": {
@@ -6818,7 +8452,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -6837,6 +8472,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -6845,10 +8481,19 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "2.0.0",
@@ -6868,8 +8513,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/sql.js": {
       "version": "1.13.0",
@@ -6894,8 +8538,11 @@
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -6949,6 +8596,7 @@
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6990,9 +8638,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -7003,6 +8668,7 @@
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -7014,9 +8680,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -7159,6 +8847,7 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -7609,6 +9298,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yaml": {

--- a/agentic-flow/package.json
+++ b/agentic-flow/package.json
@@ -25,6 +25,8 @@
     "./router/cost-optimal": "./dist/router/cost-optimal-router.js",
     "./repair": "./dist/repair/darwin-repair.js",
     "./harness/provenance": "./dist/harness/provenance.js",
+    "./harness/metaharness": "./dist/harness/metaharness.js",
+    "./harness/governance": "./dist/harness/flywheel-governance.js",
     "./agent-booster": "./dist/agent-booster/index.js",
     "./transport/quic": "./dist/transport/quic.js",
     "./embeddings": "./dist/embeddings/index.js",
@@ -67,6 +69,7 @@
     "proxy:quic:dev": "tsx src/proxy/quic-proxy.ts",
     "benchmark:embeddings": "tsx src/benchmarks/embeddings-benchmark.ts",
     "test:orchestration": "vitest run tests/orchestration/ --reporter=verbose",
+    "test:governance": "vitest run tests/harness/provenance.test.ts tests/harness/flywheel-governance.test.ts tests/mcp/mcp-policy.test.ts tests/embeddings/huggingface-offline.test.ts tests/repair/darwin-repair.test.ts",
     "test:orchestration:smoke": "tsx tests/orchestration/orchestration-api.smoke.ts && tsx tests/orchestration/loop-policy.smoke.ts && tsx tests/orchestration/memory-plane.smoke.ts"
   },
   "keywords": [
@@ -158,21 +161,20 @@
   },
   "homepage": "https://github.com/ruvnet/agentic-flow#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.5",
     "@anthropic-ai/sdk": "^0.65.0",
     "@google/genai": "^1.22.0",
-    "@metaharness/darwin": "^0.7.0",
     "@metaharness/router": "^0.3.2",
     "@ruvector/core": "^0.1.29",
     "@ruvector/edge-full": "^0.1.0",
-    "@ruvector/router": "^0.1.25",
-    "@ruvector/ruvllm": "^0.2.3",
+    "@ruvector/router": "^0.1.30",
+    "@ruvector/ruvllm": "^2.5.5",
     "@ruvector/tiny-dancer": "^0.1.17",
     "@supabase/supabase-js": "^2.78.0",
-    "@xenova/transformers": "^2.17.2",
+    "@huggingface/transformers": "^3.8.1",
     "axios": "^1.12.2",
     "dotenv": "^16.4.5",
     "express": "^5.1.0",
@@ -180,7 +182,7 @@
     "glob": "^13.0.0",
     "gun": "^0.2020.1241",
     "http-proxy-middleware": "^3.0.5",
-    "ruvector": "^0.1.85",
+    "ruvector": "0.2.40",
     "ruvector-onnx-embeddings-wasm": "^0.1.2",
     "tiktoken": "^1.0.22",
     "ulid": "^3.0.1",
@@ -195,12 +197,12 @@
     "agentdb": "^3.0.0-alpha.14",
     "better-sqlite3": "^11.10.0",
     "onnxruntime-node": "^1.23.2",
-    "sharp": "^0.32.6",
+    "sharp": "^0.34.3",
     "sql.js": "^1.11.0"
   },
   "overrides": {
     "protobufjs": ">=7.5.5",
-    "@xenova/transformers": {
+    "@huggingface/transformers": {
       "sharp": "$sharp"
     }
   },

--- a/agentic-flow/package.json
+++ b/agentic-flow/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js || true",
     "start": "node --enable-source-maps dist/index.js",
-    "build": "(npm run build:wasm || true) && (tsc -p config/tsconfig.json --skipLibCheck || true) && mkdir -p dist/reasoningbank && (cp -r src/reasoningbank/prompts dist/reasoningbank/ 2>/dev/null || true) && (cp -r src/reasoningbank/config dist/reasoningbank/ 2>/dev/null || true)",
+    "build": "(npm run build:wasm || true) && tsc -p config/tsconfig.json --skipLibCheck && mkdir -p dist/reasoningbank && (cp -r src/reasoningbank/prompts dist/reasoningbank/ 2>/dev/null || true) && (cp -r src/reasoningbank/config dist/reasoningbank/ 2>/dev/null || true)",
     "build:wasm": "cd ../reasoningbank && wasm-pack build --target bundler --out-dir pkg/bundler crates/reasoningbank-wasm && wasm-pack build --target web --out-dir pkg/web crates/reasoningbank-wasm && mkdir -p ../agentic-flow/wasm/reasoningbank && cp -r crates/reasoningbank-wasm/pkg/bundler/* ../agentic-flow/wasm/reasoningbank/ && cp -r crates/reasoningbank-wasm/pkg/web ../agentic-flow/wasm/reasoningbank/",
     "build:wasm:clean": "rm -rf ../reasoningbank/crates/reasoningbank-wasm/pkg && rm -rf wasm/reasoningbank",
     "dev": "tsx src/index.ts",

--- a/agentic-flow/src/agentdb/README.md
+++ b/agentic-flow/src/agentdb/README.md
@@ -59,7 +59,7 @@ AgentDB implements five cutting-edge memory patterns for autonomous agents, base
 ### Installation
 
 ```bash
-npm install better-sqlite3 @xenova/transformers
+npm install better-sqlite3 @huggingface/transformers
 ```
 
 ### Basic Usage

--- a/agentic-flow/src/core/embedding-service.ts
+++ b/agentic-flow/src/core/embedding-service.ts
@@ -205,7 +205,7 @@ export class TransformersEmbeddingService extends EmbeddingService {
 
     try {
       // Dynamically import transformers.js
-      const { pipeline } = await import('@xenova/transformers');
+      const { pipeline } = await import('@huggingface/transformers');
 
       this.pipeline = await pipeline('feature-extraction', this.modelName);
       this.emit('initialized', { model: this.modelName });

--- a/agentic-flow/src/embeddings/optimized-embedder.ts
+++ b/agentic-flow/src/embeddings/optimized-embedder.ts
@@ -634,7 +634,7 @@ export class OptimizedEmbedder {
     } catch (error) {
       // Fallback to transformers.js
       console.warn('ONNX Runtime not available, using transformers.js fallback');
-      const { pipeline } = await import('@xenova/transformers');
+      const { pipeline } = await import('@huggingface/transformers');
       this.tokenizer = await pipeline('feature-extraction', `Xenova/${this.config.modelId}`);
     }
 

--- a/agentic-flow/src/harness/flywheel-governance.ts
+++ b/agentic-flow/src/harness/flywheel-governance.ts
@@ -1,0 +1,189 @@
+/**
+ * Trusted evaluation/promotion boundary (ADR-077).
+ * Candidate jobs create evidence; only a trusted signer plus an atomic CAS can promote.
+ */
+import { createHash, sign as cryptoSign, verify as cryptoVerify } from 'node:crypto';
+import { evaluateMetaHarnessPromotion } from './metaharness.js';
+
+export interface BenchmarkAnchor {
+  version: 1;
+  project: string;
+  corpusHash: string;
+  embeddingSpaceHash: string;
+  indexTopologyHash: string;
+  evaluatorHash: string;
+}
+export interface PromotionMetrics {
+  primary: number;
+  noopRate: number;
+  costPerWin: number;
+  regressed?: boolean;
+}
+export interface EvaluationReceipt {
+  version: 1;
+  experimentRevision: string;
+  candidateCommit: string;
+  candidateHash: string;
+  baselineGeneration: string;
+  anchor: BenchmarkAnchor;
+  anchorHash: string;
+  gateFingerprint: string;
+  baseline: PromotionMetrics;
+  candidate: PromotionMetrics;
+  anchorMetric?: { baseline: number; candidate: number };
+  createdAt: string;
+}
+export interface PromotionProposal {
+  version: 1;
+  receipt: EvaluationReceipt;
+  receiptHash: string;
+  promote: boolean;
+  reasons: string[];
+}
+export interface PromotionAuthorization {
+  version: 1;
+  receiptHash: string;
+  candidateCommit: string;
+  expiresAt: string;
+  signer: string;
+  signature: string;
+  publicKey: string;
+}
+export interface AtomicPromotionStore {
+  compareAndSwap(expectedGeneration: string, candidateHash: string, evidenceHash: string):
+    Promise<{ promoted: boolean; generation: string }>;
+}
+export interface PromotionRecord {
+  version: 1;
+  receiptHash: string;
+  candidateCommit: string;
+  candidateHash: string;
+  previousGeneration: string;
+  generation: string;
+  signer: string;
+  promotedAt: string;
+}
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonical(object[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+export function governanceHash(value: unknown): string {
+  return createHash('sha256').update(canonical(value)).digest('hex');
+}
+function assertDigest(name: string, digest: string): void {
+  if (!/^[a-f0-9]{64}$/.test(digest)) throw new TypeError(`${name} must be a lowercase sha256 digest`);
+}
+export function createBenchmarkAnchor(input: Omit<BenchmarkAnchor, 'version'>): BenchmarkAnchor {
+  for (const field of ['corpusHash', 'embeddingSpaceHash', 'indexTopologyHash', 'evaluatorHash'] as const) {
+    assertDigest(field, input[field]);
+  }
+  if (!input.project.trim()) throw new TypeError('project is required');
+  return { version: 1, ...input };
+}
+export function createEvaluationReceipt(input: Omit<EvaluationReceipt, 'version' | 'anchorHash'>): EvaluationReceipt {
+  assertDigest('candidateHash', input.candidateHash);
+  assertDigest('gateFingerprint', input.gateFingerprint);
+  if (!input.experimentRevision.trim() || !input.candidateCommit.trim() || !input.baselineGeneration.trim()) {
+    throw new TypeError('experimentRevision, candidateCommit, and baselineGeneration are required');
+  }
+  if (!Number.isFinite(Date.parse(input.createdAt))) throw new TypeError('createdAt must be an ISO timestamp');
+  return { version: 1, ...input, anchorHash: governanceHash(input.anchor) };
+}
+export async function evaluateCandidate(receipt: EvaluationReceipt): Promise<PromotionProposal> {
+  if (receipt.anchorHash !== governanceHash(receipt.anchor)) throw new Error('benchmark anchor hash mismatch');
+  const decision = await evaluateMetaHarnessPromotion({
+    baseline: receipt.baseline,
+    candidate: receipt.candidate,
+    ...(receipt.anchorMetric ? { anchor: receipt.anchorMetric } : {}),
+  });
+  return {
+    version: 1,
+    receipt,
+    receiptHash: governanceHash(receipt),
+    promote: decision.promote,
+    reasons: [...decision.reasons],
+  };
+}
+function authorizationPayload(auth: Omit<PromotionAuthorization, 'signature' | 'publicKey'>): string {
+  return canonical(auth);
+}
+export function authorizePromotion(
+  proposal: PromotionProposal,
+  signer: string,
+  expiresAt: string,
+  privateKey: string,
+  publicKey: string,
+): PromotionAuthorization {
+  if (!proposal.promote) throw new Error('cannot authorize a rejected or inconclusive proposal');
+  const unsigned = {
+    version: 1 as const,
+    receiptHash: proposal.receiptHash,
+    candidateCommit: proposal.receipt.candidateCommit,
+    expiresAt,
+    signer,
+  };
+  const signature = cryptoSign(null, Buffer.from(authorizationPayload(unsigned)), privateKey).toString('base64');
+  return { ...unsigned, signature, publicKey };
+}
+export function verifyPromotionAuthorization(
+  proposal: PromotionProposal,
+  authorization: PromotionAuthorization,
+  now = new Date(),
+): boolean {
+  const expiry = Date.parse(authorization.expiresAt);
+  if (!proposal.promote || authorization.receiptHash !== proposal.receiptHash ||
+      authorization.candidateCommit !== proposal.receipt.candidateCommit ||
+      !Number.isFinite(expiry) || expiry <= now.getTime()) return false;
+  const { signature, publicKey, ...unsigned } = authorization;
+  try {
+    return cryptoVerify(null, Buffer.from(authorizationPayload(unsigned)), publicKey, Buffer.from(signature, 'base64'));
+  } catch {
+    return false;
+  }
+}
+export async function promoteCandidate(
+  proposal: PromotionProposal,
+  authorization: PromotionAuthorization,
+  store: AtomicPromotionStore,
+  options: { now?: Date; trustedPublicKeys: ReadonlySet<string> },
+): Promise<PromotionRecord> {
+  const now = options.now ?? new Date();
+  if (!options.trustedPublicKeys.has(authorization.publicKey)) throw new Error('untrusted promotion signer');
+  if (!verifyPromotionAuthorization(proposal, authorization, now)) throw new Error('invalid promotion authorization');
+  if (proposal.receiptHash !== governanceHash(proposal.receipt)) throw new Error('evaluation receipt hash mismatch');
+  const result = await store.compareAndSwap(
+    proposal.receipt.baselineGeneration,
+    proposal.receipt.candidateHash,
+    proposal.receiptHash,
+  );
+  if (!result.promoted) throw new Error('promotion race: baseline generation changed');
+  return {
+    version: 1,
+    receiptHash: proposal.receiptHash,
+    candidateCommit: proposal.receipt.candidateCommit,
+    candidateHash: proposal.receipt.candidateHash,
+    previousGeneration: proposal.receipt.baselineGeneration,
+    generation: result.generation,
+    signer: authorization.signer,
+    promotedAt: now.toISOString(),
+  };
+}
+export function verifyGovernanceReplay(
+  bundle: { proposal: PromotionProposal; authorization: PromotionAuthorization; promotion?: PromotionRecord },
+  options: { now?: Date; trustedPublicKeys: ReadonlySet<string> },
+): { valid: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  if (bundle.proposal.receiptHash !== governanceHash(bundle.proposal.receipt)) reasons.push('receipt hash mismatch');
+  if (!options.trustedPublicKeys.has(bundle.authorization.publicKey)) reasons.push('untrusted signer');
+  if (!verifyPromotionAuthorization(bundle.proposal, bundle.authorization, options.now)) reasons.push('invalid authorization');
+  if (bundle.promotion && (bundle.promotion.receiptHash !== bundle.proposal.receiptHash ||
+      bundle.promotion.candidateHash !== bundle.proposal.receipt.candidateHash)) {
+    reasons.push('promotion lineage mismatch');
+  }
+  return { valid: reasons.length === 0, reasons };
+}

--- a/agentic-flow/src/harness/metaharness.ts
+++ b/agentic-flow/src/harness/metaharness.ts
@@ -1,0 +1,14 @@
+/**
+ * The single lazy integration boundary for ruvector's pinned MetaHarness stack.
+ * Ordinary agentic-flow imports do not initialize research infrastructure.
+ */
+export {
+  METAHARNESS_VERSIONS,
+  assertMetaHarnessSafePayload,
+  evaluateMetaHarnessPromotion,
+  getMetaHarnessCapabilities,
+  runMetaHarnessDarwin,
+  runMetaHarnessFlywheel,
+  scanMetaHarnessRewardHacks,
+  verifyMetaHarnessReplay,
+} from 'ruvector';

--- a/agentic-flow/src/mcp/mcp-policy.ts
+++ b/agentic-flow/src/mcp/mcp-policy.ts
@@ -1,0 +1,44 @@
+export type McpProfile = 'readonly' | 'retrieval' | 'learning' | 'admin';
+
+const READONLY = [
+  /^agentic_flow_(list|list_all|agent_info|check_conflicts)/,
+  /^agentdb_(stats|pattern_search|pattern_stats)$/,
+  /^harness_(capabilities|manifest|verify)$/,
+  /parse_markdown$/,
+  /_(stats|get_profile|list_profiles|benchmark)$/,
+];
+const RETRIEVAL = [...READONLY, /search$/, /context$/];
+const LEARNING = [...RETRIEVAL, /^agentic_flow_agent$/, /^agentdb_pattern_store$/, /^sona_/];
+
+export function parseMcpProfile(value: string | undefined): McpProfile {
+  const profile = value ?? 'readonly';
+  if (!['readonly', 'retrieval', 'learning', 'admin'].includes(profile)) {
+    throw new Error(`invalid MCP profile: ${profile}`);
+  }
+  return profile as McpProfile;
+}
+
+export function isMcpToolAllowed(
+  name: string,
+  options: { profile: McpProfile; allowDarwinExecution?: boolean },
+): boolean {
+  if (name === 'harness_repair') {
+    return options.profile === 'admin' && options.allowDarwinExecution === true;
+  }
+  if (options.profile === 'admin') return true;
+  const rules = options.profile === 'learning' ? LEARNING :
+    options.profile === 'retrieval' ? RETRIEVAL : READONLY;
+  return rules.some((rule) => rule.test(name));
+}
+
+export function installMcpPolicy<T extends { addTool: (tool: { name: string }) => unknown }>(
+  server: T,
+  options: { profile: McpProfile; allowDarwinExecution?: boolean },
+): T {
+  const addTool = server.addTool.bind(server);
+  server.addTool = ((tool: { name: string }) => {
+    if (isMcpToolAllowed(tool.name, options)) return addTool(tool);
+    return undefined;
+  }) as T['addTool'];
+  return server;
+}

--- a/agentic-flow/src/mcp/standalone-stdio.ts
+++ b/agentic-flow/src/mcp/standalone-stdio.ts
@@ -5,6 +5,7 @@ import { FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import { execFileSync } from 'child_process';
 import { registerHarnessTools } from './tools/harness-tools.js';
+import { installMcpPolicy, parseMcpProfile } from './mcp-policy.js';
 
 // Security: All shell-outs use execFileSync with argv arrays (shell: false) to
 // prevent OS command injection via tool parameters (CWE-78). Do NOT reintroduce
@@ -32,6 +33,13 @@ const server = new FastMCP({
   name: 'agentic-flow',
   version: '1.0.8'
 });
+
+const mcpProfile = parseMcpProfile(process.env.AGENTIC_FLOW_MCP_PROFILE);
+installMcpPolicy(server as any, {
+  profile: mcpProfile,
+  allowDarwinExecution: process.env.AGENTIC_FLOW_MCP_ENABLE_DARWIN === 'true',
+});
+console.error(`🔐 MCP capability profile: ${mcpProfile}`);
 
 // ADR-075: harness evolution/repair + provenance tools (harness_repair,
 // harness_manifest, harness_verify).

--- a/agentic-flow/src/mcp/tools/harness-tools.ts
+++ b/agentic-flow/src/mcp/tools/harness-tools.ts
@@ -13,6 +13,7 @@
 import { z } from 'zod';
 import { repair } from '../../repair/darwin-repair.js';
 import { buildManifest, verifySignedManifest, type SignedManifest } from '../../harness/provenance.js';
+import { getMetaHarnessCapabilities } from '../../harness/metaharness.js';
 
 /** Minimal FastMCP-compatible tool descriptor (subset we use + test). */
 export interface HarnessTool {
@@ -105,7 +106,19 @@ export const harnessVerifyTool: HarnessTool = {
   },
 };
 
-export const HARNESS_TOOLS: readonly HarnessTool[] = [harnessRepairTool, harnessManifestTool, harnessVerifyTool];
+export const harnessCapabilitiesTool: HarnessTool = {
+  name: 'harness_capabilities',
+  description: 'Report the pinned ruvector MetaHarness capabilities and whether each lazy runtime is available.',
+  parameters: z.object({}),
+  execute: async (): Promise<string> => JSON.stringify(await getMetaHarnessCapabilities(), null, 2),
+};
+
+export const HARNESS_TOOLS: readonly HarnessTool[] = [
+  harnessCapabilitiesTool,
+  harnessRepairTool,
+  harnessManifestTool,
+  harnessVerifyTool,
+];
 
 /** Register all harness tools on a FastMCP-compatible server. */
 export function registerHarnessTools(server: { addTool: (tool: HarnessTool) => void }): void {

--- a/agentic-flow/src/reasoningbank/utils/embeddings.ts
+++ b/agentic-flow/src/reasoningbank/utils/embeddings.ts
@@ -3,7 +3,7 @@
  * Uses local transformers.js - no API key required!
  */
 
-import { pipeline, env } from '@xenova/transformers';
+import { pipeline, env } from '@huggingface/transformers';
 import { loadConfig } from './config.js';
 
 // Configure transformers.js to use WASM backend only (avoid ONNX runtime issues)
@@ -51,7 +51,7 @@ async function initializeEmbeddings(): Promise<void> {
       embeddingPipeline = await pipeline(
         'feature-extraction',
         'Xenova/all-MiniLM-L6-v2',
-        { quantized: true } // Smaller, faster
+        { dtype: 'q8' } // Transformers.js v3 quantized dtype
       );
       console.log('[Embeddings] Local model ready! (384 dimensions)');
     } catch (error: any) {

--- a/agentic-flow/src/repair/darwin-repair.ts
+++ b/agentic-flow/src/repair/darwin-repair.ts
@@ -22,7 +22,19 @@
  */
 
 import { resolve } from 'node:path';
-import { evolve, type EvolutionConfig, type EvolutionResult, type ArchiveRecord } from '@metaharness/darwin';
+import { runMetaHarnessDarwin } from '../harness/metaharness.js';
+
+interface ArchiveRecord {
+  score?: { finalScore?: number };
+}
+
+interface EvolutionResult {
+  baseline: ArchiveRecord | null;
+  winner: ArchiveRecord | null;
+  winnerLineage: string[];
+  generations: number;
+  records: ArchiveRecord[];
+}
 
 export type SandboxMode = 'real' | 'mock' | 'agent';
 
@@ -87,7 +99,7 @@ function finalScoreOf(record: ArchiveRecord | null): number | null {
  */
 export async function repair(opts: RepairOptions): Promise<RepairResult> {
   const repoRoot = resolve(opts.repoRoot);
-  const config: EvolutionConfig = {
+  const config = {
     repoRoot,
     workRoot: opts.workRoot ? resolve(opts.workRoot) : resolve(repoRoot, '.metaharness'),
     generations: opts.generations ?? 3,
@@ -100,7 +112,7 @@ export async function repair(opts: RepairOptions): Promise<RepairResult> {
     ...(opts.taskTimeoutMs ? { taskTimeoutMs: opts.taskTimeoutMs } : {}),
   };
 
-  const result = await evolve(config);
+  const result = await runMetaHarnessDarwin(config, { execute: true }) as EvolutionResult;
 
   const baselineScore = finalScoreOf(result.baseline) ?? 0;
   const winnerScore = finalScoreOf(result.winner);

--- a/agentic-flow/src/router/providers/onnx.ts
+++ b/agentic-flow/src/router/providers/onnx.ts
@@ -30,11 +30,11 @@ async function ensureOnnxDependencies() {
   }
   if (!transformers) {
     try {
-      const transformersModule = await import('@xenova/transformers' as any);
+      const transformersModule = await import('@huggingface/transformers' as any);
       transformers = transformersModule;
       transformers.env.allowLocalModels = true;
     } catch (e) {
-      throw new Error('@xenova/transformers not installed. Run: npm install @xenova/transformers');
+      throw new Error('@huggingface/transformers not installed. Run: npm install @huggingface/transformers');
     }
   }
 }

--- a/agentic-flow/src/services/embedding-service.ts
+++ b/agentic-flow/src/services/embedding-service.ts
@@ -202,7 +202,7 @@ export class TransformersEmbeddingService extends EmbeddingService {
 
     try {
       // Dynamically import transformers.js
-      const { pipeline } = await import('@xenova/transformers');
+      const { pipeline } = await import('@huggingface/transformers');
 
       this.pipeline = await pipeline('feature-extraction', this.modelName);
       this.emit('initialized', { model: this.modelName });

--- a/agentic-flow/src/types/e2b-optional.d.ts
+++ b/agentic-flow/src/types/e2b-optional.d.ts
@@ -1,0 +1,12 @@
+/**
+ * E2B is an optional runtime integration loaded dynamically by the SDK.
+ * Keep the base package type-checkable without forcing cloud-sandbox clients
+ * into every installation.
+ */
+declare module 'e2b' {
+  export const Sandbox: any;
+}
+
+declare module '@e2b/code-interpreter' {
+  export const Sandbox: any;
+}

--- a/agentic-flow/src/utils/model-cache.ts
+++ b/agentic-flow/src/utils/model-cache.ts
@@ -213,7 +213,7 @@ export async function getCachedTransformersPipeline(
   return modelCache.getOrLoad(
     `transformers:${task}:${model}`,
     async () => {
-      const { pipeline } = await import('@xenova/transformers');
+      const { pipeline } = await import('@huggingface/transformers');
       return pipeline(task as any, model);
     },
     200 * 1024 * 1024 // 200MB estimate for transformers model

--- a/agentic-flow/tests/embeddings/huggingface-offline.test.ts
+++ b/agentic-flow/tests/embeddings/huggingface-offline.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+describe('@huggingface/transformers packaging', () => {
+  it('loads its embedding API with remote models disabled', async () => {
+    const transformers = await import('@huggingface/transformers');
+    transformers.env.allowRemoteModels = false;
+    expect(transformers.env.allowRemoteModels).toBe(false);
+    expect(typeof transformers.pipeline).toBe('function');
+  });
+});

--- a/agentic-flow/tests/harness/flywheel-governance.test.ts
+++ b/agentic-flow/tests/harness/flywheel-governance.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { generateKeyPairPem, sha256Hex } from '../../src/harness/provenance.js';
+import {
+  authorizePromotion,
+  createBenchmarkAnchor,
+  createEvaluationReceipt,
+  evaluateCandidate,
+  governanceHash,
+  promoteCandidate,
+  verifyGovernanceReplay,
+  type PromotionProposal,
+} from '../../src/harness/flywheel-governance.js';
+
+const digest = (value: string) => sha256Hex(value);
+
+function proposal(): PromotionProposal {
+  const anchor = createBenchmarkAnchor({
+    project: 'agentic-flow',
+    corpusHash: digest('corpus'),
+    embeddingSpaceHash: digest('embedding'),
+    indexTopologyHash: digest('hnsw:m=16'),
+    evaluatorHash: digest('evaluator-v1'),
+  });
+  const receipt = createEvaluationReceipt({
+    experimentRevision: 'experiment-7',
+    candidateCommit: 'abc123',
+    candidateHash: digest('candidate'),
+    baselineGeneration: 'generation-4',
+    anchor,
+    gateFingerprint: digest('gate-v1'),
+    baseline: { primary: 0.7, noopRate: 0.1, costPerWin: 2 },
+    candidate: { primary: 0.8, noopRate: 0.05, costPerWin: 1.8 },
+    createdAt: '2026-07-29T12:00:00.000Z',
+  });
+  return { version: 1, receipt, receiptHash: governanceHash(receipt), promote: true, reasons: [] };
+}
+
+describe('Flywheel governance', () => {
+  it('delegates the frozen conjunctive gate to Flywheel 0.1.7', async () => {
+    const evaluated = await evaluateCandidate(proposal().receipt);
+    expect(evaluated.promote).toBe(true);
+    expect(evaluated.receiptHash).toBe(governanceHash(evaluated.receipt));
+  });
+
+  it('changes evidence identity when only embedding space changes', () => {
+    const first = proposal();
+    const changedAnchor = createBenchmarkAnchor({
+      ...first.receipt.anchor,
+      embeddingSpaceHash: digest('different-query-template'),
+    });
+    const changed = createEvaluationReceipt({ ...first.receipt, anchor: changedAnchor });
+    expect(changed.anchorHash).not.toBe(first.receipt.anchorHash);
+    expect(governanceHash(changed)).not.toBe(first.receiptHash);
+  });
+
+  it('requires trusted scoped authorization and an atomic baseline CAS', async () => {
+    const p = proposal();
+    const keys = generateKeyPairPem();
+    const auth = authorizePromotion(
+      p, 'release-bot', '2026-07-30T12:00:00.000Z', keys.privateKey, keys.publicKey,
+    );
+    let calls = 0;
+    const record = await promoteCandidate(p, auth, {
+      compareAndSwap: async (baseline, candidate, evidence) => {
+        calls++;
+        expect([baseline, candidate, evidence]).toEqual([
+          'generation-4', p.receipt.candidateHash, p.receiptHash,
+        ]);
+        return { promoted: true, generation: 'generation-5' };
+      },
+    }, {
+      now: new Date('2026-07-29T13:00:00.000Z'),
+      trustedPublicKeys: new Set([keys.publicKey]),
+    });
+    expect(calls).toBe(1);
+    expect(record.generation).toBe('generation-5');
+    expect(verifyGovernanceReplay(
+      { proposal: p, authorization: auth, promotion: record },
+      { now: new Date('2026-07-29T13:00:00.000Z'), trustedPublicKeys: new Set([keys.publicKey]) },
+    ).valid).toBe(true);
+  });
+
+  it('rejects expiration, tampering, and a stale baseline', async () => {
+    const p = proposal();
+    const keys = generateKeyPairPem();
+    const auth = authorizePromotion(
+      p, 'release-bot', '2026-07-30T12:00:00.000Z', keys.privateKey, keys.publicKey,
+    );
+    const expired = promoteCandidate(p, auth, {
+      compareAndSwap: async () => ({ promoted: true, generation: 'bad' }),
+    }, { now: new Date('2026-08-01T00:00:00.000Z'), trustedPublicKeys: new Set([keys.publicKey]) });
+    await expect(expired).rejects.toThrow('invalid promotion authorization');
+    await expect(promoteCandidate(p, { ...auth, expiresAt: 'never' }, {
+      compareAndSwap: async () => ({ promoted: true, generation: 'bad' }),
+    }, {
+      now: new Date('2026-07-29T13:00:00.000Z'),
+      trustedPublicKeys: new Set([keys.publicKey]),
+    })).rejects.toThrow('invalid promotion authorization');
+
+    const tampered = { ...p, receipt: { ...p.receipt, candidateCommit: 'other' } };
+    await expect(promoteCandidate(tampered, auth, {
+      compareAndSwap: async () => ({ promoted: true, generation: 'bad' }),
+    }, {
+      now: new Date('2026-07-29T13:00:00.000Z'),
+      trustedPublicKeys: new Set([keys.publicKey]),
+    })).rejects.toThrow();
+
+    await expect(promoteCandidate(p, auth, {
+      compareAndSwap: async () => ({ promoted: false, generation: 'generation-6' }),
+    }, {
+      now: new Date('2026-07-29T13:00:00.000Z'),
+      trustedPublicKeys: new Set([keys.publicKey]),
+    })).rejects.toThrow('promotion race');
+  });
+});

--- a/agentic-flow/tests/harness/provenance.test.ts
+++ b/agentic-flow/tests/harness/provenance.test.ts
@@ -82,11 +82,11 @@ describe('harness provenance — Ed25519 witness manifest', () => {
 });
 
 describe('harness MCP tools (ADR-075)', () => {
-  it('registers exactly the three harness tools', () => {
+  it('registers capability inspection plus the three harness tools', () => {
     const names: string[] = [];
     registerHarnessTools({ addTool: (t) => names.push(t.name) });
-    expect(names).toEqual(['harness_repair', 'harness_manifest', 'harness_verify']);
-    expect(HARNESS_TOOLS).toHaveLength(3);
+    expect(names).toEqual(['harness_capabilities', 'harness_repair', 'harness_manifest', 'harness_verify']);
+    expect(HARNESS_TOOLS).toHaveLength(4);
   });
 
   it('harness_manifest builds digests for the given files', async () => {

--- a/agentic-flow/tests/mcp/mcp-policy.test.ts
+++ b/agentic-flow/tests/mcp/mcp-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { installMcpPolicy, isMcpToolAllowed, parseMcpProfile } from '../../src/mcp/mcp-policy.js';
+
+describe('MCP capability profiles', () => {
+  it('defaults to readonly and rejects invalid profiles', () => {
+    expect(parseMcpProfile(undefined)).toBe('readonly');
+    expect(() => parseMcpProfile('root')).toThrow('invalid MCP profile');
+  });
+
+  it('does not expose mutations or Darwin by default', () => {
+    expect(isMcpToolAllowed('harness_verify', { profile: 'readonly' })).toBe(true);
+    expect(isMcpToolAllowed('agentdb_pattern_store', { profile: 'readonly' })).toBe(false);
+    expect(isMcpToolAllowed('harness_repair', { profile: 'readonly' })).toBe(false);
+    expect(isMcpToolAllowed('harness_repair', { profile: 'admin' })).toBe(false);
+    expect(isMcpToolAllowed('harness_repair', {
+      profile: 'admin', allowDarwinExecution: true,
+    })).toBe(true);
+  });
+
+  it('filters discovery at registration time', () => {
+    const names: string[] = [];
+    const server = installMcpPolicy({
+      addTool: (tool: { name: string }) => names.push(tool.name),
+    }, { profile: 'readonly' });
+    server.addTool({ name: 'harness_verify' });
+    server.addTool({ name: 'agent_booster_edit_file' });
+    expect(names).toEqual(['harness_verify']);
+  });
+});

--- a/docs/adr/ADR-075-metaharness-harness-evolution-and-provenance.md
+++ b/docs/adr/ADR-075-metaharness-harness-evolution-and-provenance.md
@@ -1,6 +1,8 @@
 # ADR-075: Harness Self-Evolution (Darwin) and Agent-Config Provenance (Witness Manifest)
 
-**Status**: Accepted — implemented in 2.1.0. Track A (harness MCP tools: `harness_repair` / `harness_manifest` / `harness_verify`) and Track B (Ed25519 provenance) shipped; the `metaharness` scaffolder/host-adapters remain out of scope as stated below.
+**Status**: Accepted, partially superseded by ADR-077. Darwin remains available
+through SDK/CLI, but is no longer a default MCP capability; MCP execution now
+requires the `admin` profile plus explicit Darwin opt-in.
 **Date**: 2026-06-23
 **Decision Makers**: RUV, Claude Flow Team
 **Related**: ADR-073 (Cost-Optimal Router), ADR-074 (Darwin TDR), ADR-076 (Meta-Harness Repositioning)

--- a/docs/adr/ADR-077-ruvector-metaharness-governed-promotion.md
+++ b/docs/adr/ADR-077-ruvector-metaharness-governed-promotion.md
@@ -1,0 +1,52 @@
+# ADR-077: Ruvector MetaHarness Facade and Governed Promotion
+
+**Status:** Accepted  
+**Date:** 2026-07-29  
+**Related:** ADR-073, ADR-074, ADR-075
+
+## Context
+
+Agentic-flow directly loaded Darwin and exposed repair over MCP. Evaluation and
+promotion were one trust domain, and benchmark identity was not cryptographically
+bound to the candidate. This permits stale evidence, benchmark substitution, or
+an untrusted candidate job to become its own approver.
+
+## Decision
+
+1. Use `ruvector@0.2.40` as the lazy integration facade for the pinned
+   MetaHarness stack: Darwin 0.8.0 and Flywheel 0.1.7.
+2. Bind each evaluation to a project-local benchmark anchor containing corpus,
+   embedding-space, real index-topology, and evaluator hashes.
+3. Emit a deterministic evaluation receipt and proposal. Candidate jobs have no
+   promotion credential.
+4. Promotion requires a commit-scoped, expiring Ed25519 authorization from a
+   trusted key and an atomic compare-and-swap against the evaluated baseline
+   generation.
+5. Retain proposal, authorization, and promotion record as a replay bundle.
+6. MCP defaults to `readonly`. Profiles are `readonly`, `retrieval`, `learning`,
+   and `admin`; denied tools are omitted from discovery and dispatch. Darwin is
+   available only when both the `admin` profile and
+   `AGENTIC_FLOW_MCP_ENABLE_DARWIN=true` are selected.
+7. SDK/CLI Darwin calls still require the facade's explicit `{ execute: true }`.
+8. Replace abandoned `@xenova/transformers` with
+   `@huggingface/transformers` 3.x. Release validation must import it with remote
+   model loading disabled so packaging is checked without network access.
+9. The package currently ships Claude settings, not a Codex hook manifest. In
+   response to upstream issue #2855, any future Codex hook manifest is rejected
+   from release packaging until it passes Codex's strict manifest schema; unknown
+   compatibility fields must not be emitted.
+
+## Consequences
+
+Research infrastructure remains lazy. An evaluation cannot silently promote
+itself, anchor drift changes receipt identity, stale promotions fail the store
+CAS, and replay can validate signer, receipt, and lineage. Node.js 20 becomes the
+minimum supported runtime, matching ruvector.
+
+## Acceptance
+
+- Changing only embedding-space identity changes the anchor and receipt hashes.
+- Tampered or expired authorization cannot promote.
+- Two proposals racing from one baseline allow at most one CAS.
+- Default MCP discovery contains no mutation or Darwin execution tool.
+- Darwin 0.8 and Flywheel 0.1.7 are reported through the ruvector facade.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6145,6 +6145,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/agentic-payments/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/agentic-payments/node_modules/zod": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
@@ -16694,19 +16708,6 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",


### PR DESCRIPTION
## Summary
- pin ruvector 0.2.40 with MetaHarness, Darwin 0.8, and Flywheel 0.1.7 capabilities
- add benchmark anchors, immutable receipts, trusted signing, replay verification, and atomic CAS promotion
- default MCP to readonly; require admin plus explicit opt-in for Darwin execution
- migrate direct embedding paths to `@huggingface/transformers`
- make TypeScript build failures release-blocking while retaining optional E2B loading

## Validation
- governance/offline suite: 22/22 passing
- legacy `npm test`: passing
- direct TypeScript check: passing
- full build and npm pack dry-run: passing
- production audit: 0 critical vulnerabilities

Closes #178