### PR TITLE
chore: release agentic-flow 2.1.1

### DIFF
--- a/agentic-flow/package-lock.json
+++ b/agentic-flow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-flow",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-flow",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/agentic-flow/package.json
+++ b/agentic-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-flow",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The agentic meta-harness — freeze the model, evolve the harness. An open runtime that routes each query to the cost-optimal model, evolves its own harness (planner/context/reviewer/retry/tool/memory/score policy) and autonomously repairs code, then orchestrates 66 specialized agents, 213 MCP tools, ReasoningBank memory, and multi-agent swarms on top. Built by @ruvnet on the Claude Agent SDK.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release the merged governed MetaHarness, Flywheel, MCP policy, and maintained embedding-runtime integration.

The feature PR #179 passed governance/type safety, Node 20, Node 22, build, package, and aggregate quality gates.