### PR TITLE
fix(docs): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2018,7 +2018,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ruvnet/agentic-flow&type=Date)](https://star-history.com/#ruvnet/agentic-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ruvnet/agentic-flow&type=Date)](https://star-history.dera.page/#ruvnet/agentic-flow&Date)
 
 ---
 

--- a/agentic-flow/README.md
+++ b/agentic-flow/README.md
@@ -2214,7 +2214,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ruvnet/agentic-flow&type=Date)](https://star-history.com/#ruvnet/agentic-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ruvnet/agentic-flow&type=Date)](https://star-history.dera.page/#ruvnet/agentic-flow&Date)
 
 ---
 

--- a/agentic-flow/examples/crispr-cas13-pipeline/README.md
+++ b/agentic-flow/examples/crispr-cas13-pipeline/README.md
@@ -578,7 +578,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) 
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ruvnet/agentic-flow&type=Date)](https://star-history.com/#ruvnet/agentic-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ruvnet/agentic-flow&type=Date)](https://star-history.dera.page/#ruvnet/agentic-flow&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the previous service could no longer fetch stargazer data reliably due to GitHub API restrictions. This change repoints the chart and its link to star-history.dera.page, which uses an alternative tokenless data source on the same domain, so the chart renders correctly again. Applies to README.md, agentic-flow/README.md, and agentic-flow/examples/crispr-cas13-pipeline/README.md.