### PR TITLE
fix: make the fully-local (no API key) path work — PROXY_PORT, --provider ollama, proxy base URL, ONNX model paths

### DIFF
--- a/agentic-flow/src/agents/claudeAgentDirect.ts
+++ b/agentic-flow/src/agents/claudeAgentDirect.ts
@@ -34,28 +34,28 @@ function getModelForProvider(provider: string): {
       return {
         model: envModel || 'gemini-2.0-flash-exp',
         apiKey: process.env.GOOGLE_GEMINI_API_KEY || '',
-        baseURL: process.env.GEMINI_PROXY_URL || 'http://localhost:3000'
+        baseURL: process.env.GEMINI_PROXY_URL || `http://localhost:${process.env.PROXY_PORT || '3000'}`
       };
 
     case 'requesty':
       return {
         model: envModel || 'deepseek/deepseek-chat',
         apiKey: process.env.REQUESTY_API_KEY || '',
-        baseURL: process.env.REQUESTY_PROXY_URL || 'http://localhost:3000'
+        baseURL: process.env.REQUESTY_PROXY_URL || `http://localhost:${process.env.PROXY_PORT || '3000'}`
       };
 
     case 'openrouter':
       return {
         model: envModel || 'deepseek/deepseek-chat',
         apiKey: process.env.OPENROUTER_API_KEY || '',
-        baseURL: process.env.OPENROUTER_PROXY_URL || 'http://localhost:3000'
+        baseURL: process.env.OPENROUTER_PROXY_URL || `http://localhost:${process.env.PROXY_PORT || '3000'}`
       };
 
     case 'onnx':
       return {
         model: 'onnx-local',
         apiKey: 'local',
-        baseURL: process.env.ONNX_PROXY_URL || 'http://localhost:3001'
+        baseURL: process.env.ONNX_PROXY_URL || `http://localhost:${process.env.ONNX_PROXY_PORT || '3001'}`
       };
 
     case 'anthropic':

--- a/agentic-flow/src/cli-proxy.ts
+++ b/agentic-flow/src/cli-proxy.ts
@@ -778,6 +778,7 @@ Get your key at: https://openrouter.ai/keys
       const { AnthropicToOpenRouterProxy } = await import('./proxy/anthropic-to-openrouter.js');
       const proxy = new AnthropicToOpenRouterProxy({
         openrouterApiKey: apiKey,
+        openrouterBaseUrl: process.env.ANTHROPIC_PROXY_BASE_URL,
         defaultModel: finalModel
       });
 

--- a/agentic-flow/src/cli-proxy.ts
+++ b/agentic-flow/src/cli-proxy.ts
@@ -280,6 +280,7 @@ class AgenticFlowCLI {
 
     // Determine which provider to use
     const useONNX = this.shouldUseONNX(options);
+    const useOllama = this.shouldUseOllama(options);
     const useOpenRouter = this.shouldUseOpenRouter(options);
     const useGemini = this.shouldUseGemini(options);
     // Requesty temporarily disabled - keep proxy files for future use
@@ -308,6 +309,9 @@ class AgenticFlowCLI {
       } else if (useRequesty) {
         console.log('🚀 Initializing Requesty proxy...');
         await this.startRequestyProxy(options.model);
+      } else if (useOllama) {
+        console.log('🚀 Initializing Ollama local proxy...');
+        await this.startOllamaProxy(options.model);
       } else if (useOpenRouter) {
         console.log('🚀 Initializing OpenRouter proxy...');
         await this.startOpenRouterProxy(options.model);
@@ -343,6 +347,22 @@ class AgenticFlowCLI {
     }
 
     if (process.env.USE_ONNX === 'true') {
+      return true;
+    }
+
+    return false;
+  }
+
+  private shouldUseOllama(options: any): boolean {
+    // Use Ollama if:
+    // 1. Provider is explicitly set to ollama
+    // 2. PROVIDER env var is set to ollama
+    // 3. USE_OLLAMA env var is set
+    if (options.provider === 'ollama' || process.env.PROVIDER === 'ollama') {
+      return true;
+    }
+
+    if (process.env.USE_OLLAMA === 'true') {
       return true;
     }
 
@@ -395,6 +415,13 @@ class AgenticFlowCLI {
   }
 
   private shouldUseOpenRouter(options: any): boolean {
+    // Don't use OpenRouter if Ollama is explicitly requested — otherwise a stray
+    // OPENROUTER_API_KEY in the environment captures the run via the key-based
+    // auto-selection below.
+    if (options.provider === 'ollama' || process.env.PROVIDER === 'ollama' || process.env.USE_OLLAMA === 'true') {
+      return false;
+    }
+
     // Don't use OpenRouter if ONNX, Gemini, or Requesty is explicitly requested
     if (options.provider === 'onnx' || process.env.USE_ONNX === 'true' || process.env.PROVIDER === 'onnx') {
       return false;
@@ -430,6 +457,48 @@ class AgenticFlowCLI {
     }
 
     return false;
+  }
+
+  private async startOllamaProxy(modelOverride?: string): Promise<void> {
+    // Ollama exposes an OpenAI-compatible /v1/chat/completions, which is exactly
+    // what AnthropicToOpenRouterProxy speaks — so this needs no new proxy class.
+    // The key below is a placeholder, not a credential: Ollama ignores
+    // Authorization entirely, and requiring a real one would defeat the point of
+    // a local provider.
+    const host = (process.env.OLLAMA_HOST || 'http://localhost:11434').replace(/\/+$/, '');
+
+    logger.info('Starting integrated Ollama proxy', { host });
+
+    const defaultModel = modelOverride ||
+                        process.env.OLLAMA_MODEL ||
+                        process.env.COMPLETION_MODEL ||
+                        'qwen2.5-coder:7b';
+
+    const capabilities = detectModelCapabilities(defaultModel);
+
+    const proxy = new AnthropicToOpenRouterProxy({
+      openrouterApiKey: 'ollama-local-placeholder',
+      openrouterBaseUrl: `${host}/v1`,
+      defaultModel,
+      capabilities: capabilities
+    });
+
+    proxy.start(this.proxyPort);
+    this.proxyServer = proxy;
+
+    process.env.ANTHROPIC_BASE_URL = `http://localhost:${this.proxyPort}`;
+
+    if (!process.env.ANTHROPIC_API_KEY) {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-proxy-dummy-key';
+    }
+
+    console.log(`🔗 Proxy Mode: Ollama (local, no API key)`);
+    console.log(`🔧 Proxy URL: http://localhost:${this.proxyPort}`);
+    console.log(`🔧 Ollama:    ${host}/v1`);
+    console.log(`🤖 Model:     ${defaultModel}\n`);
+
+    // Wait for proxy to be ready
+    await new Promise(resolve => setTimeout(resolve, 1500));
   }
 
   private async startOpenRouterProxy(modelOverride?: string): Promise<void> {
@@ -945,13 +1014,16 @@ PERFORMANCE:
     // Check for API key (unless using ONNX)
     const isOnnx = options.provider === 'onnx' || process.env.USE_ONNX === 'true' || process.env.PROVIDER === 'onnx';
 
-    if (!isOnnx && !useOpenRouter && !useGemini && !useRequesty && !process.env.ANTHROPIC_API_KEY) {
+    const isOllama = options.provider === 'ollama' || process.env.USE_OLLAMA === 'true' || process.env.PROVIDER === 'ollama';
+
+    if (!isOnnx && !isOllama && !useOpenRouter && !useGemini && !useRequesty && !process.env.ANTHROPIC_API_KEY) {
       console.error('\n❌ Error: ANTHROPIC_API_KEY is required\n');
       console.error('Please set your API key:');
       console.error('  export ANTHROPIC_API_KEY=sk-ant-xxxxx\n');
       console.error('Or use alternative providers:');
       console.error('  --provider openrouter  (requires OPENROUTER_API_KEY)');
       console.error('  --provider gemini      (requires GOOGLE_GEMINI_API_KEY)');
+      console.error('  --provider ollama      (free local inference via Ollama, no key)');
       console.error('  --provider onnx        (free local inference)\n');
       process.exit(1);
     }
@@ -1013,6 +1085,10 @@ PERFORMANCE:
     } else if (useGemini) {
       const model = options.model || 'gemini-2.0-flash-exp';
       console.log(`🔧 Provider: Google Gemini`);
+      console.log(`🔧 Model: ${model}\n`);
+    } else if (isOllama) {
+      const model = options.model || process.env.OLLAMA_MODEL || process.env.COMPLETION_MODEL || 'qwen2.5-coder:7b';
+      console.log(`🔧 Provider: Ollama (local, no API key)`);
       console.log(`🔧 Model: ${model}\n`);
     } else if (options.provider === 'onnx' || process.env.USE_ONNX === 'true' || process.env.PROVIDER === 'onnx') {
       console.log(`🔧 Provider: ONNX Local (Phi-4-mini)`);
@@ -1216,7 +1292,7 @@ WORKERS COMMANDS:
 OPTIONS:
   --task, -t <task>           Task description for agent mode
   --model, -m <model>         Model to use (triggers OpenRouter if contains "/")
-  --provider, -p <name>       Provider to use (anthropic, openrouter, gemini, onnx)
+  --provider, -p <name>       Provider to use (anthropic, openrouter, gemini, onnx, ollama)
   --stream, -s                Enable real-time streaming output
   --help, -h                  Show this help message
 

--- a/agentic-flow/src/cli-proxy.ts
+++ b/agentic-flow/src/cli-proxy.ts
@@ -53,7 +53,7 @@ const VERSION = packageJson.version;
 
 class AgenticFlowCLI {
   private proxyServer: any = null;
-  private proxyPort: number = 3000;
+  private proxyPort: number = parseInt(process.env.PROXY_PORT || '3000', 10);
 
   async start() {
     const options = parseArgs();

--- a/agentic-flow/src/router/providers/onnx-local-optimized.ts
+++ b/agentic-flow/src/router/providers/onnx-local-optimized.ts
@@ -21,7 +21,7 @@ try {
 }
 
 import { get_encoding } from 'tiktoken';
-import { ensurePhi4Model, ModelDownloader } from '../../utils/model-downloader.js';
+import { ensurePhi4Model, ModelDownloader, PHI4_MODEL_PATH } from '../../utils/model-downloader.js';
 import type {
   ChatParams,
   ChatResponse,
@@ -50,7 +50,7 @@ export class OptimizedONNXProvider extends ONNXLocalProvider {
     super(config);
 
     this.optimizedConfig = {
-      modelPath: config.modelPath || './models/phi-4-mini/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx',
+      modelPath: config.modelPath || PHI4_MODEL_PATH,
       executionProviders: config.executionProviders || ['cpu'],
       maxTokens: config.maxTokens || 200,
       temperature: config.temperature || 0.3,  // Lower for code (more deterministic)

--- a/agentic-flow/src/router/providers/onnx-local.ts
+++ b/agentic-flow/src/router/providers/onnx-local.ts
@@ -19,7 +19,7 @@ try {
 import * as fs from 'fs';
 import * as path from 'path';
 import { get_encoding } from 'tiktoken';
-import { ensurePhi4Model, ModelDownloader } from '../../utils/model-downloader.js';
+import { ensurePhi4Model, ModelDownloader, PHI4_MODEL_PATH } from '../../utils/model-downloader.js';
 import type {
   LLMProvider,
   ChatParams,
@@ -51,7 +51,7 @@ export class ONNXLocalProvider implements LLMProvider {
 
   constructor(config: ONNXLocalConfig = {}) {
     this.config = {
-      modelPath: config.modelPath || './models/phi-4/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx',
+      modelPath: config.modelPath || PHI4_MODEL_PATH,
       executionProviders: config.executionProviders || ['cpu'],
       maxTokens: config.maxTokens || 100,
       temperature: config.temperature || 0.7

--- a/agentic-flow/src/router/providers/onnx-phi4.ts
+++ b/agentic-flow/src/router/providers/onnx-phi4.ts
@@ -6,6 +6,7 @@
  */
 
 import { HfInference } from '@huggingface/inference';
+import { PHI4_MODEL_PATH } from '../../utils/model-downloader.js';
 import type {
   LLMProvider,
   ChatParams,
@@ -33,7 +34,7 @@ export class ONNXPhi4Provider implements LLMProvider {
 
   private config: Required<ONNXPhi4Config>;
   private hf: HfInference;
-  private modelPath = './models/phi-4/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx';
+  private modelPath = PHI4_MODEL_PATH;
 
   constructor(config: ONNXPhi4Config = {}) {
     this.config = {

--- a/agentic-flow/src/router/router.ts
+++ b/agentic-flow/src/router/router.ts
@@ -19,6 +19,7 @@ import { AnthropicProvider } from './providers/anthropic.js';
 import { ONNXLocalProvider } from './providers/onnx-local.js';
 import { GeminiProvider } from './providers/gemini.js';
 import { OllamaProvider } from './providers/ollama.js';
+import { PHI4_MODEL_PATH } from '../utils/model-downloader.js';
 
 export class ModelRouter {
   private config: RouterConfig;
@@ -166,7 +167,7 @@ export class ModelRouter {
         const provider = new ONNXLocalProvider({
           modelPath:
             this.config.providers.onnx.modelPath ||
-            './models/phi-4/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx',
+            PHI4_MODEL_PATH,
           executionProviders: this.config.providers.onnx.executionProviders || ['cpu'],
           maxTokens: this.config.providers.onnx.maxTokens || 100,
           temperature: this.config.providers.onnx.temperature || 0.7,

--- a/agentic-flow/src/router/test-onnx-benchmark.ts
+++ b/agentic-flow/src/router/test-onnx-benchmark.ts
@@ -5,6 +5,7 @@
  */
 
 import { ONNXLocalProvider } from './providers/onnx-local.js';
+import { PHI4_MODEL_PATH } from '../utils/model-downloader.js';
 
 interface BenchmarkResult {
   test: string;
@@ -19,7 +20,7 @@ async function runBenchmark() {
   console.log('================================================\n');
 
   const provider = new ONNXLocalProvider({
-    modelPath: './models/phi-4/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx',
+    modelPath: PHI4_MODEL_PATH,
     executionProviders: ['cpu'],
     maxTokens: 50,
     temperature: 0.7

--- a/agentic-flow/src/router/test-onnx-local.ts
+++ b/agentic-flow/src/router/test-onnx-local.ts
@@ -4,13 +4,14 @@
  */
 
 import { ONNXLocalProvider } from './providers/onnx-local.js';
+import { PHI4_MODEL_PATH } from '../utils/model-downloader.js';
 
 async function testONNXLocal() {
   console.log('🧪 Testing ONNX Local Inference (Phi-4 CPU)\n');
 
   try {
     const provider = new ONNXLocalProvider({
-      modelPath: './models/phi-4/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx',
+      modelPath: PHI4_MODEL_PATH,
       executionProviders: ['cpu'],
       maxTokens: 50
     });

--- a/agentic-flow/src/utils/model-downloader.ts
+++ b/agentic-flow/src/utils/model-downloader.ts
@@ -9,6 +9,27 @@ import { dirname, join } from 'path';
 import { pipeline } from 'stream/promises';
 import { createHash } from 'crypto';
 import { readFileSync } from 'fs';
+import { homedir } from 'os';
+
+/**
+ * Where ONNX models live on disk.
+ *
+ * These paths were previously relative ('./models/...'), so they resolved
+ * against process.cwd() and a ~4.6GB download landed in whatever directory the
+ * command happened to run from — re-downloaded once per working directory, and
+ * left untracked inside any repository it was invoked in.
+ *
+ * Exported so the reader (router/providers/onnx-local.ts) can resolve the same
+ * path the writer uses; the two previously disagreed (phi-4 vs phi-4-mini).
+ */
+export const MODEL_ROOT = process.env.AGENTIC_FLOW_MODEL_DIR
+  || join(homedir(), '.agentic-flow', 'models');
+
+export const PHI4_MODEL_PATH = join(
+  MODEL_ROOT, 'phi-4-mini', 'cpu_and_mobile', 'cpu-int4-rtn-block-32-acc-level-4', 'model.onnx'
+);
+
+export const PHI4_MODEL_DATA_PATH = `${PHI4_MODEL_PATH}.data`;
 
 export interface DownloadProgress {
   downloaded: number;
@@ -34,13 +55,13 @@ export class ModelDownloader {
   private phi4Model: ModelInfo = {
     repo: 'microsoft/Phi-4-mini-instruct-onnx',
     filename: 'cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx',
-    localPath: './models/phi-4-mini/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx'
+    localPath: PHI4_MODEL_PATH
   };
 
   private phi4ModelData: ModelInfo = {
     repo: 'microsoft/Phi-4-mini-instruct-onnx',
     filename: 'cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx.data',
-    localPath: './models/phi-4-mini/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx.data'
+    localPath: PHI4_MODEL_DATA_PATH
   };
 
   /**


### PR DESCRIPTION
Fixes five defects that together make `agentic-flow` unusable for a fully local,
no-API-key setup. Each commit is atomic and maps to one issue.

| Commit | Issue | Defect |
|---|---|---|
| `5273a11` | #223 | `PROXY_PORT` honoured on the bind but not on the dial |
| `a07574d` | #224 | `--provider ollama` accepted and then silently ignored |
| `f0cc1ea` | #225 | `runStandaloneProxy` drops `ANTHROPIC_PROXY_BASE_URL` |
| `bb3f2f5` | #226 | ONNX model paths resolved under `process.cwd()` |
| `2d2d24a` | #227 | ONNX downloader and readers resolve *different* paths |

They are in one PR because three of the five touch `src/cli-proxy.ts` and
separate PRs would conflict on merge. **Happy to split per issue if you prefer** —
say the word and I'll open five.

---

## #223 — `PROXY_PORT` on the dial

`cli-proxy.ts` read `PROXY_PORT` when starting the proxy but `claudeAgentDirect.ts`
hardcoded `http://localhost:3000` in three places, so setting `PROXY_PORT` moved the
listener and left the client dialling the old port. This is a regression of #81.

Also fixes the ONNX sibling at line 58 (`ONNX_PROXY_PORT`, default 3001), which had
the same shape.

**Verified:** with `:3000` deliberately held by another process, `PROXY_PORT=3999`
now completes a request end to end. Before the change the same invocation failed
`ECONNREFUSED 127.0.0.1:3000`.

## #224 — `--provider ollama`

`--provider ollama` parsed without error, then fell through every `shouldUseX()`
guard to the Anthropic path and demanded `ANTHROPIC_API_KEY`. There was no code
path to a local Ollama at all.

Ollama already serves an OpenAI-compatible `/v1/chat/completions`, so this needs no
new proxy class — `AnthropicToOpenRouterProxy` is reused with
`openrouterBaseUrl: ${host}/v1` and a placeholder key (Ollama ignores auth).
9 edits: the guard, the branch, the launcher, the key check, the error text, the
display line and the help text.

**Verified:** `--provider ollama --model qwen2.5-coder:7b` with **no API key set at
all**, asked to echo a nonsense sentinel token, returned it exactly **5 times out
of 5**. The sentinel was chosen to have no plausible alternate spelling after a
first attempt used a real word and the model "corrected" it.

## #225 — `openrouterBaseUrl` in the standalone proxy

`runStandaloneProxy()` constructed the proxy without passing `openrouterBaseUrl`,
so `ANTHROPIC_PROXY_BASE_URL` was silently ignored in exactly the mode where a
user is most likely to set it.

## #226 / #227 — ONNX model paths

`model-downloader.ts` wrote the model under `join(process.cwd(), '.agentic-flow', ...)`
while six reader sites each rebuilt their own path — some relative to `cwd`, some
not. Running the CLI from a different directory silently re-downloaded, and the
reader could look somewhere the writer had never written.

#226 exports `MODEL_ROOT` / `PHI4_MODEL_PATH` / `PHI4_MODEL_DATA_PATH` rooted at
`~/.agentic-flow/models` (overridable via `AGENTIC_FLOW_MODEL_DIR`).
#227 points all six readers at the exported constant, so writer and readers cannot
diverge again.

---

## Verification notes, including the limits

- Behaviour was verified against the **built 2.1.2 `dist/`** with the equivalent
  edits applied, not against a fresh `npm run build` of this branch — the clone has
  no `node_modules` and this repo's install is large. The TypeScript here is the
  same change, typecheck-clean, but **the built artefact was not re-verified from
  this branch** and I'd rather say so than imply otherwise.
- Each commit typechecks with `tsc --noEmit --skipLibCheck`. Zero `TS1xxx` syntax
  errors introduced. Two pre-existing diagnostics (`TS2591`, `TS18048`) are
  unchanged — confirmed by stashing the branch and re-running: 2 before, 2 after.
- For #224 the discriminator between "the local path ran" and "it fell through to
  Anthropic" is the error shape, not the exit code: before the change, 7 runs
  produced `proxy_error` and 0 produced a completion; after, 0 `proxy_error` and
  the completions above. `ECONNREFUSED` went 2 → 0 for #223 on the same basis.
- The edits were applied and reverted round-trip; the reverted tree was
  byte-identical to the original.

Tested on macOS 26.6.1 (arm64), Node v22.23.0, Ollama 0.32.5 with `qwen2.5-coder:7b`.
